### PR TITLE
Drop IE7 support in the grid framework

### DIFF
--- a/app/Resources/views/home/show.html.twig
+++ b/app/Resources/views/home/show.html.twig
@@ -58,12 +58,12 @@
                 <p>Get started by searching for a programme, browsing the <a href="/programmes/a-z/by/a">A-Z</a>, or choosing a <a href="/programmes/genres">genre</a>.</p>
 
                 <div class="grid-wrapper">
-                    <div class="grid bpb2-one-half bpw-one-half"><div class="grid__inner">
+                    <div class="grid bpb2-one-half bpw-one-half">
                         <p><a href="/iplayer"><img src="{{asset('images/logos/iplayer.png')}}" class="rsp-img" alt="iPlayer" /></a></p>
-                    </div></div>
-                    <div class="grid bpb2-one-half bpw-one-half"><div class="grid__inner">
+                    </div>
+                    <div class="grid bpb2-one-half bpw-one-half">
                         <p><a href="/radio"><img src="{{asset('images/logos/iplayer_radio.png')}}" class="rsp-img" alt="iPlayer Radio" /></a></p>
-                    </div></div>
+                    </div>
                 </div>
 
                 <p>Where applicable episodes will be available to watch at <a href="/iplayer">BBC iPlayer</a> or listen through <a href="/radio">BBC iPlayer Radio</a>.</p>
@@ -75,38 +75,38 @@
         <h2>{{tr('schedules')}}</h2>
 
         <div class="grid-wrapper">
-            <div class="grid bpw2-one-quarter bpe-one-quarter"><div class="grid__inner">
+            <div class="grid bpw2-one-quarter bpe-one-quarter">
                 <h3 class="gamma--keyline br-keyline">{{tr('television_abbr')}}</h3>
                 <ul class="list-unindented columns bpb2-columns--2 bpw-columns--2 bpw2-columns--1 bpe-columns--1" data-list="tv-networks">
                     {% for network in tvNetworks %}
                         <li><a href="{{path('schedules_by_day', {'pid': network.defaultService.pid})}}">{{network.name}}</a></li>
                     {% endfor %}
                 </ul>
-            </div></div>
-            <div class="grid bpw2-one-half bpe-one-half"><div class="grid__inner">
+            </div>
+            <div class="grid bpw2-one-half bpe-one-half">
                 <h3 class="gamma--keyline br-keyline">{{tr('national_radio')}}</h3>
                 <ul class="list-unindented columns bpb2-columns--2 bpw-columns--2" data-list="national-radio-networks">
                     {% for network in nationalRadioNetworks %}
                         <li><a href="{{path('schedules_by_day', {'pid': network.defaultService.pid})}}">{{network.name|replace({'BBC': ''})|trim}}</a></li>
                     {% endfor %}
                 </ul>
-            </div></div>
-            <div class="grid bpw2-one-quarter bpe-one-quarter"><div class="grid__inner">
+            </div>
+            <div class="grid bpw2-one-quarter bpe-one-quarter">
                 <h3 class="gamma--keyline br-keyline">{{tr('nations_radio')}}</h3>
                 <ul class="list-unindented columns bpb2-columns--2 bpw-columns--2 bpw2-columns--1 bpe-columns--1" data-list="regional-radio-networks">
                     {% for network in regionalRadioNetworks %}
                         <li><a href="{{path('schedules_by_day', {'pid': network.defaultService.pid})}}">{{network.name|replace({'BBC': ''})|trim}}</a></li>
                     {% endfor %}
                 </ul>
-            </div></div>
-            <div class="grid bpw-one-whole"><div class="grid__inner">
+            </div>
+            <div class="grid bpw-one-whole">
                 <h3 class="gamma--keyline br-keyline">{{tr('local_radio')}}</h3>
                 <ul class="list-unindented columns bpb2-columns--2 bpw-columns--2 bpw2-columns--4 bpe-columns--4" data-list="local-radio-networks">
                     {% for network in localRadioNetworks %}
                         <li><a href="{{path('schedules_by_day', {'pid': network.defaultService.pid})}}">{{network.name|replace({'BBC': ''})|trim}}</a></li>
                     {% endfor %}
                 </ul>
-            </div></div>
+            </div>
         </div>
     </div>
 </div>

--- a/app/Resources/views/home/show.html.twig
+++ b/app/Resources/views/home/show.html.twig
@@ -58,10 +58,10 @@
                 <p>Get started by searching for a programme, browsing the <a href="/programmes/a-z/by/a">A-Z</a>, or choosing a <a href="/programmes/genres">genre</a>.</p>
 
                 <div class="grid-wrapper">
-                    <div class="grid bpb2-one-half bpw-one-half">
+                    <div class="grid 1/2@bpb2 1/2@bpw">
                         <p><a href="/iplayer"><img src="{{asset('images/logos/iplayer.png')}}" class="rsp-img" alt="iPlayer" /></a></p>
                     </div>
-                    <div class="grid bpb2-one-half bpw-one-half">
+                    <div class="grid 1/2@bpb2 1/2@bpw">
                         <p><a href="/radio"><img src="{{asset('images/logos/iplayer_radio.png')}}" class="rsp-img" alt="iPlayer Radio" /></a></p>
                     </div>
                 </div>
@@ -75,33 +75,33 @@
         <h2>{{tr('schedules')}}</h2>
 
         <div class="grid-wrapper">
-            <div class="grid bpw2-one-quarter bpe-one-quarter">
+            <div class="grid 1/4@bpw2 1/4@bpe">
                 <h3 class="gamma--keyline br-keyline">{{tr('television_abbr')}}</h3>
-                <ul class="list-unindented columns bpb2-columns--2 bpw-columns--2 bpw2-columns--1 bpe-columns--1" data-list="tv-networks">
+                <ul class="list-unindented columns columns--2@bpb2 columns--2@bpw columns--1@bpw2 columns--1@bpe" data-list="tv-networks">
                     {% for network in tvNetworks %}
                         <li><a href="{{path('schedules_by_day', {'pid': network.defaultService.pid})}}">{{network.name}}</a></li>
                     {% endfor %}
                 </ul>
             </div>
-            <div class="grid bpw2-one-half bpe-one-half">
+            <div class="grid 1/2@bpw2 1/2@bpe">
                 <h3 class="gamma--keyline br-keyline">{{tr('national_radio')}}</h3>
-                <ul class="list-unindented columns bpb2-columns--2 bpw-columns--2" data-list="national-radio-networks">
+                <ul class="list-unindented columns columns--2@bpb2 columns--2@bpw" data-list="national-radio-networks">
                     {% for network in nationalRadioNetworks %}
                         <li><a href="{{path('schedules_by_day', {'pid': network.defaultService.pid})}}">{{network.name|replace({'BBC': ''})|trim}}</a></li>
                     {% endfor %}
                 </ul>
             </div>
-            <div class="grid bpw2-one-quarter bpe-one-quarter">
+            <div class="grid 1/4@bpw2 1/4@bpe">
                 <h3 class="gamma--keyline br-keyline">{{tr('nations_radio')}}</h3>
-                <ul class="list-unindented columns bpb2-columns--2 bpw-columns--2 bpw2-columns--1 bpe-columns--1" data-list="regional-radio-networks">
+                <ul class="list-unindented columns columns--2@bpb2 columns--2@bpw columns--1@bpw2 columns--1@bpe" data-list="regional-radio-networks">
                     {% for network in regionalRadioNetworks %}
                         <li><a href="{{path('schedules_by_day', {'pid': network.defaultService.pid})}}">{{network.name|replace({'BBC': ''})|trim}}</a></li>
                     {% endfor %}
                 </ul>
             </div>
-            <div class="grid bpw-one-whole">
+            <div class="grid">
                 <h3 class="gamma--keyline br-keyline">{{tr('local_radio')}}</h3>
-                <ul class="list-unindented columns bpb2-columns--2 bpw-columns--2 bpw2-columns--4 bpe-columns--4" data-list="local-radio-networks">
+                <ul class="list-unindented columns columns--2@bpb2 columns--2@bpw bpw2-columns--4 bpe-columns--4" data-list="local-radio-networks">
                     {% for network in localRadioNetworks %}
                         <li><a href="{{path('schedules_by_day', {'pid': network.defaultService.pid})}}">{{network.name|replace({'BBC': ''})|trim}}</a></li>
                     {% endfor %}

--- a/src/Ds2013/Atom/_columns.scss
+++ b/src/Ds2013/Atom/_columns.scss
@@ -5,7 +5,7 @@
 
 @mixin column-setup($namespace: '') {
     @for $i from 1 through 4 {
-        .#{$namespace}columns--#{$i} {
+        .columns--#{$i}#{$namespace} {
             -webkit-column-count:#{$i};
                -moz-column-count:#{$i};
                     column-count:#{$i};
@@ -45,6 +45,6 @@
 
 @each $name in $gel-widths-breakpoints {
     @include mq-range($name) {
-       @include column-setup('#{$name}-');
+       @include column-setup('\\@#{$name}');
     }
 }

--- a/src/Ds2013/Core/Base/_prog-layout.scss
+++ b/src/Ds2013/Core/Base/_prog-layout.scss
@@ -21,9 +21,9 @@
 // </div>
 //
 // <div class="pro-layout"><div class="grid-wrapper">
-//     <div class="grid bpw-one-half"><div class="grid__inner">
+//     <div class="grid bpw-one-half">
 //         <div class="prog-layout__primary">I am some simple content</div>
-//     </div></div>
+//     </div>
 // </div></div>
 //
 .prog-layout {

--- a/src/Ds2013/Core/Gel/Objects/_grid.scss
+++ b/src/Ds2013/Core/Gel/Objects/_grid.scss
@@ -1,36 +1,38 @@
 /**
  * Grid object.
  *
- * An IE 7 compatible implementation of a fluid grid with fixed gutter sizes.
+ * An IE 8 compatible implementation of a fluid grid with fixed gutter sizes.
  * Use in conjunction with the width objects to set the sizing of your grid
  * items.
  *
- * The .grid__inner div is required for IE7 compatibility. If we drop support
- * for IE 7 then we can use box-sizing:border-box; and apply the padding
- * directly to the .grid element, thus removing the need for the nested div.
+ * The original grid from programmes had IE7 compatibility by using an inner
+ * `grid__inner` div rather than using box-sizing: border-box.
+ * As we no longer care about IE7 support we've moved to use border-box and apply
+ * padding directly to the `grid` element, which means we can get rid of that
+ * now-unneeded `grid__inner` div.
  *
  * Sample usage:
  *
  * <div class="grid-wrapper">
- *      <div class="grid one-third"><div class="grid__inner">
+ *      <div class="grid one-third">
  *          <p>One third grid</p>
- *      </div></div>
+ *      </div>
  *
- *      <div class="grid two-thirds"><div class="grid__inner">
+ *      <div class="grid two-thirds">
  *          <p>Two thirds grid</p>
- *      </div></div>
+ *      </div>
  *
- *      <div class="grid one-half"><div class="grid__inner">
+ *      <div class="grid one-half">
  *          <p>One half grid</p>
- *      </div></div>
+ *      </div>
  *
- *      <div class="grid one-quarter"><div class="grid__inner">
+ *      <div class="grid one-quarter">
  *          <p>One quarter grid</p>
- *      </div></div>
+ *      </div>
  *
- *      <div class="grid one-quarter"><div class="grid__inner">
+ *      <div class="grid one-quarter">
  *          <p>One quarter grid</p>
- *      </div></div>
+ *      </div>
  *   </div>
  */
 
@@ -81,11 +83,17 @@ $gel-grid-gutter-wide-half: $gel-grid-gutter-wide / 2;
     zoom: 1;
     vertical-align: top;
 
-    // In case people want to use a * { box-sizing: border-box; } declaration
-    // as per http://paulirish.com/2012/box-sizing-border-box-ftw/
-    -moz-box-sizing: content-box;
-    -webkit-box-sizing: content-box;
-    box-sizing: content-box;
+    // In case people want to use a * { box-sizing: content-box; } declaration
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+
+    padding-left: $gel-grid-gutter-basic;
+
+    // Reset whitespace spacing
+    letter-spacing: normal;
+    word-spacing: normal;
+    text-rendering: auto;
 
     // Grid components have a default width so that you don't need to always
     // use the .one-whole class for mobile-first implementations
@@ -102,15 +110,6 @@ $gel-grid-gutter-wide-half: $gel-grid-gutter-wide / 2;
     width: 100%;
 }
 
-#{$gel-class-prefix}grid__inner {
-    padding-left: $gel-grid-gutter-basic;
-
-    // Reset whitespace spacing
-    letter-spacing: normal;
-    word-spacing: normal;
-    text-rendering: auto;
-}
-
 #{$gel-class-prefix}grid-wrapper--center {
     text-align:center;
 
@@ -122,7 +121,8 @@ $gel-grid-gutter-wide-half: $gel-grid-gutter-wide / 2;
 #{$gel-class-prefix}grid-wrapper--bothsides {
     margin-left: -$gel-grid-gutter-basic-half;
     margin-right: -$gel-grid-gutter-basic-half;
-    #{$gel-class-prefix}grid__inner {
+
+    #{$gel-class-prefix}grid {
         padding-left: $gel-grid-gutter-basic-half;
         padding-right: $gel-grid-gutter-basic-half;
     }
@@ -133,7 +133,7 @@ $massive-pushdown: 50em;
 #{$gel-class-prefix}grid-wrapper--fauxcolumn {
     overflow: hidden;
 
-    #{$gel-class-prefix}grid__inner {
+    #{$gel-class-prefix}grid {
         margin-bottom: -$massive-pushdown;
         padding-bottom: $massive-pushdown;
     }
@@ -157,14 +157,15 @@ $massive-pushdown: 50em;
     }
 
 
-    #{$gel-class-prefix}grid__inner {
+    #{$gel-class-prefix}grid {
         padding-left: $gel-grid-gutter-wide;
     }
 
     #{$gel-class-prefix}grid-wrapper--bothsides {
         margin-left: -$gel-grid-gutter-wide-half;
         margin-right: -$gel-grid-gutter-wide-half;
-        #{$gel-class-prefix}grid__inner {
+
+        #{$gel-class-prefix}grid {
             padding-left: $gel-grid-gutter-wide-half;
             padding-right: $gel-grid-gutter-wide-half;
         }
@@ -186,7 +187,7 @@ $massive-pushdown: 50em;
         margin-left: 0;
     }
 
-    #{$gel-class-prefix}#{$namespace}grid__inner--flush {
+    #{$gel-class-prefix}#{$namespace}grid--flush {
         padding-right: 0;
         padding-left: 0;
     }
@@ -196,7 +197,7 @@ $massive-pushdown: 50em;
         margin-left: -$spacing / 2;
     }
 
-    #{$gel-class-prefix}#{$namespace}grid__inner--half {
+    #{$gel-class-prefix}#{$namespace}grid--half {
         padding-right: 0;
         padding-left: $spacing / 2;
     }

--- a/src/Ds2013/Core/Gel/Objects/_hidden.scss
+++ b/src/Ds2013/Core/Gel/Objects/_hidden.scss
@@ -4,12 +4,12 @@
  * Helper classes to show or hide blocks based on the current breakpoint
  */
 
-@mixin gel-hidden-setup($namespace: '', $class-prefix: $gel-class-prefix) {
-    #{$class-prefix}#{$namespace}hidden {
+@mixin gel-hidden-setup($suffix: '') {
+    .hidden#{$suffix} {
         display: none !important;
     }
 
-    #{$class-prefix}#{$namespace}visible {
+    .visible#{$suffix} {
         display: inherit !important;
         // IE 7 doesn't support display:inherit, so make the (slightly terrible)
         // assumption that we're toggling the visibility of a block level
@@ -17,7 +17,7 @@
         *display: block !important;
     }
 
-    #{$class-prefix}#{$namespace}grid-visible {
+    .grid-visible#{$suffix} {
         display: inline-block !important;
         // IE 7 doesn't support display:inline-block so fall back to inline.
        *display: inline !important;
@@ -31,6 +31,6 @@
  */
 @each $name in $gel-widths-breakpoints {
     @include mq-range($name) {
-       @include gel-hidden-setup('#{$name}-');
+       @include gel-hidden-setup('\\@#{$name}');
     }
 }

--- a/src/Ds2013/Core/Gel/Objects/_widths.scss
+++ b/src/Ds2013/Core/Gel/Objects/_widths.scss
@@ -1,12 +1,19 @@
 /**
  * Widths.
  *
- * Human readable width abstractions.
+ * In the old system we used word based names for the classes e.g. "one-third"
+ * and "three-quarters". This was overly verbose, so instead move to a more
+ * amen-like style of using fractional classes e.g. "1/3" and "3/4".
+ * In the old system breakpoints were prefixed e.g. "bpw-one-third". This was
+ * also slightly janky as the fraction is more important than the breakpoint.
+ * We have moved to a more amen-like style of suffixing using the @ symbol to
+ * denote widths only triggering at specific breakpoints e.g. "1/3@bpw".
  *
- * Heavily inspired by:
- * http://csswizardry.com/2013/02/responsive-grid-systems-a-solution/
- *
- * For sample usage see grid.
+ * The strange numbers at the front are unicode values,
+ * as CSS classes cannot start with an unescaped number.
+ * They are complex here, so that the HTML itself is clean.
+ * You'd never need to write odd these values anywhere else.
+ * They are suffixed with the breakpoints. e.g. .1/3@bpw
  */
 
 
@@ -14,55 +21,57 @@
  * Grid width sizing ratios, these have grid-agnostic names as they can also
  * be used for items within a grid, such as on .media__img
  */
-@mixin gel-widths-setup($namespace: '', $class-prefix: $gel-class-prefix) {
+@mixin gel-widths-setup($suffix: '') {
     // Whole
-    #{$class-prefix}#{$namespace}one-whole         { width:100%; }
+    .\31\/1#{$suffix} { width: (1/1) * 100%; } // .1/1
 
     // Halves
-    #{$class-prefix}#{$namespace}one-half          { width:50%; }
+    .\31\/2#{$suffix} { width: (1/2) * 100%; } // .1/2
 
-    // Thirds
-    #{$class-prefix}#{$namespace}one-third         { width:33.333%; }
-    #{$class-prefix}#{$namespace}two-thirds        { width:66.666%; }
+    // Thirds (prime number)
+    .\31\/3#{$suffix} { width: (1/3) * 100%; } // .1/3
+    .\32\/3#{$suffix} { width: (2/3) * 100%; } // .2/3
 
     // Quarters
-    #{$class-prefix}#{$namespace}one-quarter       { width:25%; }
-    #{$class-prefix}#{$namespace}three-quarters    { width:75%; }
+    .\31\/4#{$suffix} { width: (1/4) * 100%; } // .1/4
+    .\33\/4#{$suffix} { width: (3/4) * 100%; } // .3/4
 
-    // Fifths (only be used with one-fifth & four-fifths for 100% total)
-    #{$class-prefix}#{$namespace}one-fifth         { width:20%; }
-    #{$class-prefix}#{$namespace}four-fifths       { width:80%; }
+    // Fifths (prime number)
+    .\31\/5#{$suffix} { width: (1/5) * 100%; } // .1/5
+    .\32\/5#{$suffix} { width: (2/5) * 100%; } // .2/5
+    .\33\/5#{$suffix} { width: (3/5) * 100%; } // .3/5
+    .\34\/5#{$suffix} { width: (4/5) * 100%; } // .4/5
 
     // Sixths
-    #{$class-prefix}#{$namespace}one-sixth         { width:16.666%; }
-    #{$class-prefix}#{$namespace}five-sixths       { width:83.333%; }
+    .\31\/6#{$suffix} { width: (1/6) * 100%; } // .1/6
+    .\35\/6#{$suffix} { width: (5/6) * 100%; } // .5/6
 
     // Eigths
     // Simplified fractions of the 24 column grid
-    #{$class-prefix}#{$namespace}one-eighth       { width:12.5%; }
+    .\31\/8#{$suffix} { width: (1/8) * 100%; } // .1/8
+    .\32\/8#{$suffix} { width: (3/8) * 100%; } // .3/8
+    .\35\/8#{$suffix} { width: (5/8) * 100%; } // .5/8
+    .\37\/8#{$suffix} { width: (7/8) * 100%; } // .7/8
+
 
     // Twelfths
-    #{$class-prefix}#{$namespace}one-twelfth       { width:8.333%; }
-    #{$class-prefix}#{$namespace}five-twelfths     { width:41.666% }
-    #{$class-prefix}#{$namespace}seven-twelfths    { width:58.333%; }
-    #{$class-prefix}#{$namespace}eleven-twelfths   { width:91.666%; }
+    .\31\/12#{$suffix} { width: (1/12) * 100%; } // .1/12
+    .\35\/12#{$suffix} { width: (5/12) * 100%; } // .5/12
+    .\37\/12#{$suffix} { width: (7/12) * 100%; } // .7/12
+    .\41\/12#{$suffix} { width: (11/12) * 100%; } // .11/12
 
     // Sixteenths
     // Off the beaten track, but it can be used on 1:1 images so they appear to
     // be the same height as a 16:9 image with the class one-quarter
-    #{$class-prefix}#{$namespace}three-sixteenths       { width:18.75%; }
+    .\33\/16#{$suffix} { width: (3/16) * 100%; } // .3/16
 
     // Twenty-fourths
     // Only used for advert box at full size, so we aren't including the full
     // set of possible class names
-    #{$class-prefix}#{$namespace}five-twentyfourths       { width:20.833%; }
-    #{$class-prefix}#{$namespace}seven-twentyfourths       { width:29.166%; }
-    #{$class-prefix}#{$namespace}eleven-twentyfourths       { width: (11/24) * 100%; }
-    #{$class-prefix}#{$namespace}thirteen-twentyfourths       { width: (13/24) * 100%; }
-
-    // TODO these should be simplified down to eigths
-    #{$class-prefix}#{$namespace}nine-twentyfourths       { width:37.5%; }
-    #{$class-prefix}#{$namespace}fifteen-twentyfourths      { width:62.5%; }
+    .\35\/16#{$suffix} { width: (5/24) * 100%; } // .5/24
+    .\37\/16#{$suffix} { width: (7/24) * 100%; } // .7/24
+    .\41\/16#{$suffix} { width: (11/24) * 100%; } // 11/24
+    .\43\/16#{$suffix} { width: (13/24) * 100%; } // 13/24
 }
 
 
@@ -73,6 +82,6 @@
  */
 @each $name in $gel-widths-breakpoints {
     @include mq-range($name) {
-       @include gel-widths-setup('#{$name}-');
+       @include gel-widths-setup('\\@#{$name}');
     }
 }

--- a/src/Ds2013/Core/Helpers/_widths.scss
+++ b/src/Ds2013/Core/Helpers/_widths.scss
@@ -1,35 +1,3 @@
-@mixin widths-setup-fixed($namespace: '', $base-size: 976px) {
-    // Whole
-    .#{$namespace}one-whole-fixed         { width:$base-size * 1.00 ; }
-
-    // Halves
-    .#{$namespace}one-half-fixed          { width:$base-size * 0.50; }
-
-    // Thirds
-    .#{$namespace}one-third-fixed         { width:$base-size * 0.33333; }
-    .#{$namespace}two-thirds-fixed        { width:$base-size * 0.66666; }
-
-    // Quarters
-    .#{$namespace}one-quarter-fixed       { width:$base-size * 0.25; }
-    .#{$namespace}three-quarters-fixed    { width:$base-size * 0.75; }
-
-    // Sixths
-    .#{$namespace}one-sixth-fixed         { width:$base-size * 0.16666; }
-    .#{$namespace}five-sixths-fixed       { width:$base-size * 0.83333; }
-
-    // Twelfths
-    .#{$namespace}one-twelfth-fixed       { width:$base-size * 0.08333; }
-    .#{$namespace}five-twelfths-fixed     { width:$base-size * 0.41666 }
-    .#{$namespace}seven-twelfths-fixed    { width:$base-size * 0.58333; }
-    .#{$namespace}eleven-twelfths-fixed   { width:$base-size * 0.91666; }
-
-    // Twenty-fourths
-    // Only used for advert box at full size, so we aren't including the full
-    // set of possible class names
-    .#{$namespace}nine-twentyfourths-fixed       { width:$base-size * 0.375; }
-    .#{$namespace}fifteen-twentyfourths-fixed      { width:$base-size * 0.625; }
-}
-
 // When a single column looks too wide but two side-by-side columns looks
 // too skinny use a grid--bounded to have a single column with some spacing
 // around it (best used with grid-wrapper--center).
@@ -44,13 +12,13 @@
         overflow: auto; // Stop content peeking out underneath columns to the left
     }
 
-    @include widths-setup-fixed('bpw-');
+    .\31\/6\\@bpw { width: 976px * 0.16666; }
 }
 
 // For letting you undo grid-unbounded at a given breakpoint
 @each $name in $gel-widths-breakpoints {
     @include mq-range($name) {
-           .#{$name}-grid--unbounded {
+           .grid--unbounded\\@#{$name} {
             max-width: none;
         }
     }


### PR DESCRIPTION
Moving to use box-sizing:border-box means we can remove that inner div
that we previously needed to create fixed width gutters.