### PR TITLE
Pass in Translate to presenters only when required

### DIFF
--- a/src/Ds2013/Organism/Broadcast/BroadcastPresenter.php
+++ b/src/Ds2013/Organism/Broadcast/BroadcastPresenter.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 namespace App\Ds2013\Organism\Broadcast;
 
 use App\Ds2013\Presenter;
-use App\Ds2013\PresenterFactory;
 use BBC\ProgrammesPagesService\Domain\ApplicationTime;
 use BBC\ProgrammesPagesService\Domain\Entity\Broadcast;
 use DateTimeImmutable;
@@ -24,11 +23,10 @@ class BroadcastPresenter extends Presenter
     private $now;
 
     public function __construct(
-        PresenterFactory $ds2013,
         Broadcast $broadcast,
         array $options = []
     ) {
-        parent::__construct($ds2013, $options);
+        parent::__construct($options);
         $this->broadcast = $broadcast;
         $this->now = ApplicationTime::getTime();
     }

--- a/src/Ds2013/Organism/Programme/ProgrammePresenter.php
+++ b/src/Ds2013/Organism/Programme/ProgrammePresenter.php
@@ -3,11 +3,14 @@ declare(strict_types = 1);
 namespace App\Ds2013\Organism\Programme;
 
 use App\Ds2013\Presenter;
-use App\Ds2013\PresenterFactory;
+use App\Ds2013\TranslatableTrait;
 use BBC\ProgrammesPagesService\Domain\Entity\Programme;
+use RMP\Translate\Translate;
 
 class ProgrammePresenter extends Presenter
 {
+    use TranslatableTrait;
+
     protected $options = [
         'showSynosis' => true,
     ];
@@ -16,11 +19,12 @@ class ProgrammePresenter extends Presenter
     private $programme;
 
     public function __construct(
-        PresenterFactory $ds2013,
+        Translate $translate,
         Programme $programme,
         array $options = []
     ) {
-        parent::__construct($ds2013, $options);
+        parent::__construct($options);
+        $this->translate = $translate;
         $this->programme = $programme;
     }
 
@@ -41,6 +45,6 @@ class ProgrammePresenter extends Presenter
 
     public function getLocale(): string
     {
-        return $this->presenterFactory->getTranslate()->getLocale();
+        return $this->translate->getLocale();
     }
 }

--- a/src/Ds2013/Presenter.php
+++ b/src/Ds2013/Presenter.php
@@ -15,14 +15,9 @@ abstract class Presenter
     /** @var string */
     protected $uniqueId;
 
-    /** @var PresenterFactory */
-    protected $presenterFactory;
-
     public function __construct(
-        PresenterFactory $presenterFactory,
         array $options = []
     ) {
-        $this->presenterFactory = $presenterFactory;
         $this->options = array_merge($this->options, $options);
     }
 
@@ -80,26 +75,6 @@ abstract class Presenter
         }
 
         return trim(implode(' ', $cssClasses));
-    }
-
-
-    protected function tr(
-        string $key,
-        $substitutions = [],
-        $numPlurals = null,
-        ?string $domain = null
-    ): string {
-        // this code is duplicating the function extension for the twig template. Same code. Can be improved this?
-        if (is_int($substitutions) && is_null($numPlurals)) {
-            $numPlurals = $substitutions;
-            $substitutions = array('%count%' => $numPlurals);
-        }
-
-        if (is_int($numPlurals) && !isset($substitutions['%count%'])) {
-            $substitutions['%count%'] = $numPlurals;
-        }
-
-        return $this->presenterFactory->getTranslate()->translate($key, $substitutions, $numPlurals, $domain);
     }
 
     /**

--- a/src/Ds2013/PresenterFactory.php
+++ b/src/Ds2013/PresenterFactory.php
@@ -13,8 +13,7 @@ use RMP\Translate\Translate;
  *
  * This abstraction shall allow us to have a single entry point to create any
  * Presenter. This is particularly valuable in two cases:
- * 1) When a presenter depends upon another presenter - we can pass in this
- *    factory to all presenters to it is trivial to create an new one
+ * 1) When presenters require Translate, we have a single point to inject it
  * 2) When we have multiple Domain objects that should all be rendered using the
  *    same template. This factory allows us to choose the correct presenter for
  *    a given domain object.
@@ -23,7 +22,7 @@ use RMP\Translate\Translate;
  * which have presenters.
  * Each respective group MUST have the methods kept in alphabetical order
  *
- * To instantiate Amen you MUST pass it a translation locale (e.g en_GB)
+ * To instantiate Ds2013 you MUST pass it an instance of Translate
  * All presenters MUST be created using this factory.
  * All presenters MUST call the base Presenter __construct method
  *
@@ -56,7 +55,7 @@ class PresenterFactory
         array $options = []
     ): ProgrammePresenter {
         return new ProgrammePresenter(
-            $this,
+            $this->translate,
             $programme,
             $options
         );
@@ -67,7 +66,6 @@ class PresenterFactory
         array $options = []
     ): BroadcastPresenter {
         return new BroadcastPresenter(
-            $this,
             $broadcast,
             $options
         );

--- a/src/Ds2013/TranslatableTrait.php
+++ b/src/Ds2013/TranslatableTrait.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types = 1);
+namespace App\Ds2013;
+
+use RMP\Translate\Translate;
+
+trait TranslatableTrait
+{
+    /** @var Translate */
+    protected $translate;
+
+    protected function tr(
+        string $key,
+        $substitutions = [],
+        $numPlurals = null,
+        ?string $domain = null
+    ): string {
+        if (is_int($substitutions) && is_null($numPlurals)) {
+            $numPlurals = $substitutions;
+            $substitutions = array('%count%' => $numPlurals);
+        }
+
+        if (is_int($numPlurals) && !isset($substitutions['%count%'])) {
+            $substitutions['%count%'] = $numPlurals;
+        }
+
+        return $this->translate->translate($key, $substitutions, $numPlurals, $domain);
+    }
+}

--- a/src/Twig/DesignSystemPresenterExtension.php
+++ b/src/Twig/DesignSystemPresenterExtension.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 namespace App\Twig;
 
 use App\Ds2013\PresenterFactory as Ds2013PresenterFactory;
+use App\Ds2013\TranslatableTrait;
 use Twig_Environment;
 use Twig_Extension;
 use Twig_Function;
@@ -10,7 +11,7 @@ use RMP\Translate\Translate;
 
 class DesignSystemPresenterExtension extends Twig_Extension
 {
-    private $translate;
+    use TranslatableTrait;
 
     private $ds2013PresenterFactory;
 
@@ -41,7 +42,7 @@ class DesignSystemPresenterExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_Function('tr', [$this, 'tr']),
+            new Twig_Function('tr', [$this, 'trWrapper']),
             new Twig_Function('ds2013', [$this, 'ds2013'], [
                 'is_safe' => ['html'],
                 'is_variadic' => true,
@@ -50,22 +51,13 @@ class DesignSystemPresenterExtension extends Twig_Extension
         ];
     }
 
-    public function tr(
+    public function trWrapper(
         string $key,
         $substitutions = [],
         $numPlurals = null,
         ?string $domain = null
     ): string {
-        if (is_int($substitutions) && is_null($numPlurals)) {
-            $numPlurals = $substitutions;
-            $substitutions = array('%count%' => $numPlurals);
-        }
-
-        if (is_int($numPlurals) && !isset($substitutions['%count%'])) {
-            $substitutions['%count%'] = $numPlurals;
-        }
-
-        return $this->translate->translate($key, $substitutions, $numPlurals, $domain);
+        return $this->tr($key, $substitutions, $numPlurals, $domain);
     }
 
     public function ds2013(


### PR DESCRIPTION
Now that the ds2013() twig function exists we don't need to do weird
things with passing the PresenterFactory into every presenter because
the twig template deals with the creation of any dependant presenters
(e.g. rending an image presenter within a programme presenter).
No presenters shall need the Factory passed in as an argument.

However we still sometimes want to use the translation function within
some Presenters. So create a TranslatablePresenterTrait for these
presenters to use. These presenters should pass an instance of Translate
in as the first argument (not a hard and fast rule but seems like a
sensible convention).