### PR TITLE
Use isActiveAt / isOnAirAt utils from pages-service

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -212,16 +212,16 @@
         },
         {
             "name": "bbc/programmes-pages-service",
-            "version": "v2.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bbc/programmes-pages-service.git",
-                "reference": "c606313ec4943afa35c92a9486d86aac9bc08af0"
+                "reference": "39a84a3a41b9045d27de68d9b02791897ed95190"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bbc/programmes-pages-service/zipball/c606313ec4943afa35c92a9486d86aac9bc08af0",
-                "reference": "c606313ec4943afa35c92a9486d86aac9bc08af0",
+                "url": "https://api.github.com/repos/bbc/programmes-pages-service/zipball/39a84a3a41b9045d27de68d9b02791897ed95190",
+                "reference": "39a84a3a41b9045d27de68d9b02791897ed95190",
                 "shasum": ""
             },
             "require": {
@@ -255,10 +255,10 @@
             ],
             "description": "A library for building /programmes pages",
             "support": {
-                "source": "https://github.com/bbc/programmes-pages-service/tree/v2.0.0",
+                "source": "https://github.com/bbc/programmes-pages-service/tree/v2.0.1",
                 "issues": "https://github.com/bbc/programmes-pages-service/issues"
             },
-            "time": "2017-05-09T16:38:54+00:00"
+            "time": "2017-05-15T14:56:36+00:00"
         },
         {
             "name": "behat/transliterator",

--- a/src/Ds2013/Organism/Broadcast/BroadcastPresenter.php
+++ b/src/Ds2013/Organism/Broadcast/BroadcastPresenter.php
@@ -52,14 +52,9 @@ class BroadcastPresenter extends Presenter
         return 'http://www.bbc.co.uk/programmes/' . $pid;
     }
 
-    public function isNow(): bool
+    public function isOnAirNow(): bool
     {
-        return $this->broadcast->getStartAt() <= $this->now && $this->now < $this->broadcast->getEndAt();
-    }
-
-    public function isInThePast(): bool
-    {
-        return $this->broadcast->getEndAt() < $this->now;
+        return $this->broadcast->isOnAirAt($this->now);
     }
 
     public function getNetworkMedium(): string
@@ -83,7 +78,12 @@ class BroadcastPresenter extends Presenter
             $this->getOption('container_classes') => !empty($this->getOption('container_classes')),
             $this->getOption('highlight_box_classes') => !empty($this->getOption('highlight_box_classes')),
             'br-keyline br-blocklink-page br-page-linkhover-onbg015--hover' => $this->getOption('highlight_box_classes'),
-            'br-box-subtle highlight-box--active' => $this->getOption('steal_blocklink') and $this->isNow(),
+            'br-box-subtle highlight-box--active' => $this->getOption('steal_blocklink') && $this->isOnAirNow(),
         ]);
+    }
+
+    private function isInThePast(): bool
+    {
+        return $this->broadcast->getEndAt() < $this->now;
     }
 }

--- a/src/Ds2013/Organism/Broadcast/broadcast.html.twig
+++ b/src/Ds2013/Organism/Broadcast/broadcast.html.twig
@@ -15,7 +15,7 @@
                     <meta property="name" content="{{broadcast.getServiceName()}}" />
                 </span>
 
-                {% if broadcast.isNow() %}
+                {% if broadcast.isOnAirNow() %}
                     <div class="broadcast__live centi br-box-highlight">
                         {{ broadcast.getNetworkMedium() == 'tv' ? tr('on_now') : tr('on_air') }}
                     </div>


### PR DESCRIPTION
We've moved some datetime logic into pages-service, so use it.
Some slight tweaks to naming while I'm in there.