### PR TITLE
Fix gulp-sass compilation behaviour

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@
 
 const gulp = require('gulp');
 const sass = require('gulp-sass');
+const { gulpSassError } = require('gulp-sass-error');
 const sourcemaps = require('gulp-sourcemaps');
 const rev = require('gulp-rev');
 const revdelOriginal = require('gulp-rev-delete-original');
@@ -12,6 +13,7 @@ const staticPathDist = 'web/assets';
 const sassMatch = '/sass/**/*.scss';
 const imageMatch = '/images/*';
 
+var throwError = true;
 // ------
 
 gulp.task('sass:clean', function() {
@@ -24,7 +26,7 @@ gulp.task('sass', ['sass:clean'], function() {
         .pipe(sass({outputStyle: 'compressed', includePaths: [
             'src',
             'node_modules'
-        ]}).on('error', sass.logError))
+        ]}).on('error', gulpSassError(throwError)))
         .pipe(sourcemaps.write())
         .pipe(gulp.dest(staticPathDist + '/css/'));
 });
@@ -55,6 +57,11 @@ gulp.task('rev', ['sass', 'images'], function() {
  * Entry tasks
  */
 gulp.task('watch',function() {
+    // When watching we don't want to throw an error, because then we have to
+    // go and restart the watch task if we ever write invalid sass, which would
+    // be really annoying.
+    throwError = false;
+
     gulp.watch(
         [staticPathSrc + sassMatch, 'src/**/*.scss'],
         ['sass']

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "gulp-rev": "^7.1.2",
         "gulp-rev-delete-original": "^0.2.3",
         "gulp-sass": "^3.1.0",
+        "gulp-sass-error": "^1.0.5",
         "gulp-sourcemaps": "^2.4.1",
         "sass-mq": "^3.3.2"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,6 +682,12 @@ gulp-rev@^7.1.2:
     through2 "^2.0.0"
     vinyl-file "^1.1.0"
 
+gulp-sass-error@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/gulp-sass-error/-/gulp-sass-error-1.0.5.tgz#1f35cb20b9585f3fc993da68c502bc243f5c3efb"
+  dependencies:
+    gulp-util "^3.0.7"
+
 gulp-sass@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/gulp-sass/-/gulp-sass-3.1.0.tgz#53dc4b68a1f5ddfe4424ab4c247655269a8b74b7"
@@ -707,7 +713,7 @@ gulp-sourcemaps@^2.4.1:
     through2 "2.X"
     vinyl "1.X"
 
-gulp-util@^3.0, gulp-util@^3.0.0:
+gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.7:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:


### PR DESCRIPTION
Previously the gulp build would succeed even if there was an error in
sass compilation. This makes sure we exit with a non-zero error code if
there is a sass compilation error. Running watch shall output the error
messages but won't interupt the watch if there was an error.