### PR TITLE
Class attribute building

### DIFF
--- a/src/Ds2013/Molecule/DateList/DateListItemPresenter.php
+++ b/src/Ds2013/Molecule/DateList/DateListItemPresenter.php
@@ -45,30 +45,14 @@ class DateListItemPresenter extends Presenter
         return $this->buildHtmlAttributes(['data-href-add-utcoffset' => 'true']);
     }
 
-    public function getCssClassesForItem(): string
-    {
-        $shouldShowLink = $this->shouldShowLink();
-        return $this->buildCssClasses([
-            'br-page-bg-onbg--hover br-page-linkhover-ontext--hover' => $shouldShowLink,
-            'br-box-page' => ($this->offset == 0),
-            'text--faded' => ($this->offset != 0 && !$shouldShowLink),
-        ]);
-    }
-
-    public function getCssClassesForLi(): string
-    {
-        return $this->buildCssClasses([
-            'date-list__page' => true,
-            'date-list__page--offset' . abs($this->offset) => true,
-            'date-list__page--first' => $this->offset == -7,
-            'date-list__page--last' => $this->offset == 7,
-            'date-list__page--current' => ($this->offset == 0),
-        ]);
-    }
-
     public function getDatetime(): DateTimeImmutable
     {
         return $this->datetime;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
     }
 
     public function isToday(): bool
@@ -81,7 +65,7 @@ class DateListItemPresenter extends Presenter
         return (string) $this->service->getPid();
     }
 
-    public function shouldShowLink(): bool
+    public function isLink(): bool
     {
         // if the date is more than 90 DAYS from now, then don't allow a link (page will still exist)
         return $this->offset != 0 &&

--- a/src/Ds2013/Molecule/DateList/DateListItemPresenter.php
+++ b/src/Ds2013/Molecule/DateList/DateListItemPresenter.php
@@ -47,11 +47,6 @@ class DateListItemPresenter extends Presenter
         return $this->offset;
     }
 
-    public function isToday(): bool
-    {
-        return ApplicationTime::getTime()->format('Y-m-d') == $this->datetime->format('Y-m-d');
-    }
-
     public function getServicePid(): string
     {
         return (string) $this->service->getPid();
@@ -68,5 +63,10 @@ class DateListItemPresenter extends Presenter
     public function isGmt(): bool
     {
         return $this->options['user_timezone'] == 'GMT';
+    }
+
+    public function isToday(): bool
+    {
+        return ApplicationTime::getTime()->format('Y-m-d') == $this->datetime->format('Y-m-d');
     }
 }

--- a/src/Ds2013/Molecule/DateList/DateListItemPresenter.php
+++ b/src/Ds2013/Molecule/DateList/DateListItemPresenter.php
@@ -37,14 +37,6 @@ class DateListItemPresenter extends Presenter
         $this->offset = $offset;
     }
 
-    public function getAttributesForItem(): string
-    {
-        if ($this->options['user_timezone'] == 'GMT') {
-            return '';
-        }
-        return $this->buildHtmlAttributes(['data-href-add-utcoffset' => 'true']);
-    }
-
     public function getDatetime(): DateTimeImmutable
     {
         return $this->datetime;
@@ -71,5 +63,10 @@ class DateListItemPresenter extends Presenter
         return $this->offset != 0 &&
             ApplicationTime::getTime()->add(new DateInterval('P90D')) > $this->datetime &&
             $this->service->isActiveAt($this->datetime);
+    }
+
+    public function isGmt(): bool
+    {
+        return $this->options['user_timezone'] == 'GMT';
     }
 }

--- a/src/Ds2013/Molecule/DateList/date_list_item.html.twig
+++ b/src/Ds2013/Molecule/DateList/date_list_item.html.twig
@@ -1,14 +1,28 @@
 {% spaceless %}
     {% import _self as self %}
 
-    <li class="{{ date_list_item.cssClassesForLi }}">
-        {% if date_list_item.shouldShowLink %}
+    {% set li_classes = build_css_classes({
+        'date-list__page': true,
+        ('date-list__page--offset' ~ date_list_item.offset|abs): true,
+        'date-list__page--first': date_list_item.offset == -7,
+        'date-list__page--last': date_list_item.offset == 7,
+        'date-list__page--current': (date_list_item.offset == 0),
+    }) %}
+
+    {% set item_classes = build_css_classes({
+        'br-page-bg-onbg--hover br-page-linkhover-ontext--hover': date_list_item.isLink,
+        'br-box-page': date_list_item.offset == 0,
+        'text--faded': date_list_item.offset != 0 and not date_list_item.isLink,
+    }) %}
+
+    <li class="{{ li_classes }}">
+        {% if date_list_item.isLink %}
             <a href="{{ path('schedules_by_day', {'pid': date_list_item.servicePid, 'date': date_list_item.datetime.format('Y-m-d')}) }}"
-               class="{{ date_list_item.cssClassesForItem }}" {{ date_list_item.attributesForItem }}>
+               class="{{ item_classes }}" {{ date_list_item.attributesForItem }}>
                 {{ self.dateLines(date_list_item.isToday, date_list_item.datetime) }}
             </a>
         {% else %}
-            <span class="{{ date_list_item.cssClassesForItem }}">
+            <span class="{{ item_classes }}">
                 {{ self.dateLines(date_list_item.isToday, date_list_item.datetime) }}
             </span>
         {% endif %}

--- a/src/Ds2013/Molecule/DateList/date_list_item.html.twig
+++ b/src/Ds2013/Molecule/DateList/date_list_item.html.twig
@@ -15,10 +15,12 @@
         'text--faded': date_list_item.offset != 0 and not date_list_item.isLink,
     }) %}
 
+    {% set item_attributes = date_list_item.isGmt ? 'data-href-add-utcoffset="beans"' %}
+
     <li class="{{ li_classes }}">
         {% if date_list_item.isLink %}
             <a href="{{ path('schedules_by_day', {'pid': date_list_item.servicePid, 'date': date_list_item.datetime.format('Y-m-d')}) }}"
-               class="{{ item_classes }}" {{ date_list_item.attributesForItem }}>
+               class="{{ item_classes }}" {{ item_attributes|raw }}>
                 {{ self.dateLines(date_list_item.isToday, date_list_item.datetime) }}
             </a>
         {% else %}

--- a/src/Ds2013/Organism/Broadcast/BroadcastPresenter.php
+++ b/src/Ds2013/Organism/Broadcast/BroadcastPresenter.php
@@ -61,18 +61,9 @@ class BroadcastPresenter extends Presenter
         return $this->broadcast->getProgrammeItem()->getNetwork()->getMedium();
     }
 
-
-
     public function getProgrammeItem()
     {
         return $this->broadcast->getProgrammeItem();
-    }
-
-    public function getInfoClasses(): string
-    {
-        return $this->buildCssClasses([
-            '1/4 1/6@bpb2 1/6@bpw' => $this->getOption('is_stacked'),
-        ]);
     }
 
     public function getMessageIsNow(): string
@@ -84,27 +75,7 @@ class BroadcastPresenter extends Presenter
         return 'on_air';
     }
 
-    public function getObjectClasses(): string
-    {
-        return $this->buildCssClasses([
-            'broadcast' => true,
-            'broadcast--has-ended' => $this->isInThePast(),
-            'block-link block-link--steal' => $this->getOption('steal_blocklink'),
-            $this->getOption('container_classes') => !empty($this->getOption('container_classes')),
-            $this->getOption('highlight_box_classes') => !empty($this->getOption('highlight_box_classes')),
-            'br-keyline br-blocklink-page br-page-linkhover-onbg015--hover' => $this->getOption('highlight_box_classes'),
-            'br-box-subtle highlight-box--active' => $this->getOption('steal_blocklink') && $this->isOnAirNow(),
-        ]);
-    }
-
-    public function getProgrammeClasses()
-    {
-        return $this->buildCssClasses([
-                '3/4 5/6@bpb2 5/6@bpw' => !$this->getOption('is_stacked'),
-        ]);
-    }
-
-    private function isInThePast(): bool
+    public function isInThePast(): bool
     {
         return $this->broadcast->getEndAt() < $this->now;
     }

--- a/src/Ds2013/Organism/Broadcast/broadcast.html.twig
+++ b/src/Ds2013/Organism/Broadcast/broadcast.html.twig
@@ -1,6 +1,24 @@
-<div class="{{ broadcast.objectClasses }}" vocab="http://schema.org/" typeof="BroadcastEvent">
+{% set broadcast_classes = build_css_classes({
+    'broadcast': true,
+    'broadcast--has-ended': broadcast.isInThePast,
+    'block-link block-link--steal': broadcast.option('steal_blocklink'),
+    (broadcast.option('container_classes')): broadcast.option('container_classes'),
+    (broadcast.option('highlight_box_classes')): broadcast.option('highlight_box_classes'),
+    'br-keyline br-blocklink-page br-page-linkhover-onbg015--hover': broadcast.option('highlight_box_classes'),
+    'br-box-subtle highlight-box--active': broadcast.option('steal_blocklink') and broadcast.isOnAirNow,
+}) %}
+
+{% set info_classes = build_css_classes({
+    '1/4 1/6@bpb2 1/6@bpw': not broadcast.option('is_stacked'),
+}) %}
+
+{% set programme_classes = build_css_classes({
+    '3/4 5/6@bpb2 5/6@bpw': not broadcast.option('is_stacked'),
+}) %}
+
+<div class="{{ broadcast_classes }}" vocab="http://schema.org/" typeof="BroadcastEvent">
     <div class="grid-wrapper">
-        <div class="broadcast__info grid {{ broadcast.infoClasses }}">
+        <div class="broadcast__info grid {{ info_classes }}">
                 {#start time and zone#}
                 <h3 class="broadcast__time gamma" data-timezone="true" property="startDate" datatype="xsd:dateTime" content={{ broadcast.startAt|date('c') }}>
                     <span class="timezone--time">{{broadcast.startAt|date('H:i')}}</span>
@@ -21,12 +39,11 @@
                     </div>
                 {% endif %}
         </div>
-        <div class="broadcast__programme grid {{ broadcast.programmeClasses }}" rev="publication">
+        <div class="broadcast__programme grid {{ programme_classes }}" rev="publication">
             <div class="grid__inner">
 
             </div>
         </div>
-
     </div>
 </div>
 

--- a/src/Ds2013/Presenter.php
+++ b/src/Ds2013/Presenter.php
@@ -82,18 +82,6 @@ abstract class Presenter
         return $this->uniqueId;
     }
 
-    protected function buildCssClasses(array $cssClassTests = []): string
-    {
-        $cssClasses = [];
-        foreach ($cssClassTests as $cssClass => $shouldSet) {
-            if ($shouldSet) {
-                $cssClasses[] = $cssClass;
-            }
-        }
-
-        return trim(implode(' ', $cssClasses));
-    }
-
     protected function buildHtmlAttributes(array $htmlAttributes = []): string
     {
         $attributes = [];

--- a/src/Ds2013/Presenter.php
+++ b/src/Ds2013/Presenter.php
@@ -82,17 +82,6 @@ abstract class Presenter
         return $this->uniqueId;
     }
 
-    protected function buildHtmlAttributes(array $htmlAttributes = []): string
-    {
-        $attributes = [];
-
-        foreach ($htmlAttributes as $attribute => $value) {
-            $attributes[] = $attribute . '="' . htmlentities($value, ENT_COMPAT, 'UTF-8') . '"';
-        }
-
-        return trim(implode(' ', $attributes));
-    }
-
     /**
      * Validate options. Should be overridden.
      */

--- a/src/Twig/HtmlUtilitiesExtension.php
+++ b/src/Twig/HtmlUtilitiesExtension.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types = 1);
+namespace App\Twig;
+
+use Twig_Extension;
+use Twig_Function;
+
+class HtmlUtilitiesExtension extends Twig_Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new Twig_Function('build_css_classes', [$this, 'buildCssClasses']),
+        ];
+    }
+
+    public function buildCssClasses(array $cssClassTests = []): string
+    {
+        $cssClasses = [];
+        foreach ($cssClassTests as $cssClass => $shouldSet) {
+            if ($shouldSet) {
+                $cssClasses[] = $cssClass;
+            }
+        }
+
+        return trim(implode(' ', $cssClasses));
+    }
+}

--- a/tests/Ds2013/Organism/Broadcast/BroadcastPresenterTest.php
+++ b/tests/Ds2013/Organism/Broadcast/BroadcastPresenterTest.php
@@ -17,7 +17,7 @@ class BroadcastPresenterTest extends TestCase
     /**
      * @dataProvider datesProvider
      */
-    public function testClassesBasedOnStatusBroadcast($start, $end, $cssClass, $isOnAir)
+    public function testClassesBasedOnStatusBroadcast($start, $end, $isOnAir)
     {
         // set now
         $timestamp = (new DateTimeImmutable('2017-05-18 08:30:00'))->getTimestamp();
@@ -35,21 +35,16 @@ class BroadcastPresenterTest extends TestCase
             false
         );
 
-        $presenter = new BroadcastPresenter(
-            $broadcast,
-            ['highlight_box_classes' => 'my-highglight-class']
-        );
+        $presenter = new BroadcastPresenter($broadcast);
 
         $this->assertEquals($isOnAir, $presenter->isOnAirNow());
-        $this->assertContains($cssClass, $presenter->getObjectClasses());
-        $this->assertContains('my-highglight-class', $presenter->getObjectClasses());
     }
 
     public function datesProvider()
     {
         return [
-            ['2017-05-18 07:00:00', '2017-05-18 08:00:00', 'broadcast--has-ended', false],
-            ['2017-05-18 08:00:00', '2017-05-18 09:00:00', 'highlight-box--active', true],
+            ['2017-05-18 07:00:00', '2017-05-18 08:00:00', false],
+            ['2017-05-18 08:00:00', '2017-05-18 09:00:00', true],
         ];
     }
 }

--- a/tests/Ds2013/PresenterTest.php
+++ b/tests/Ds2013/PresenterTest.php
@@ -40,17 +40,6 @@ class PresenterTest extends TestCase
         $this->assertSame(null, $presenter->getOption('garbage'));
     }
 
-    public function testBuildCssClasses()
-    {
-        $buildCssClassesFn = $this->boundCall('buildCssClasses');
-
-        $this->assertSame('foo baz qux', $buildCssClassesFn([
-            'foo' => true,
-            'bar' => false,
-            'baz qux' => true,
-        ]));
-    }
-
     public function testGetUniqueID()
     {
         $presenter = $this->getMockForAbstractClass(Presenter::class, [], 'TestDemoObjectPresenter');

--- a/tests/Twig/HtmlUtilitiesExtensionTest.php
+++ b/tests/Twig/HtmlUtilitiesExtensionTest.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types = 1);
+namespace Tests\App\Twig;
+
+use App\Twig\HtmlUtilitiesExtension;
+use PHPUnit\Framework\TestCase;
+
+class HtmlUtilitiesExtensionTest extends TestCase
+{
+    public function testBuildCssClasses()
+    {
+        $extension = new HtmlUtilitiesExtension();
+        $this->assertSame('foo baz qux', $extension->buildCssClasses([
+            'foo' => true,
+            'bar' => false,
+            'baz qux' => true,
+        ]));
+    }
+}


### PR DESCRIPTION
Defining classes and attributes in templates makes more sense as then they're much nearer to where they're used. Having to flit between two files to find the css classes that are used in a given case is annoying.

So thus define classes in the presenters.