### PR TITLE
Throw helpful error if you reference an unknown presenter option

### DIFF
--- a/src/Ds2013/InvalidOptionException.php
+++ b/src/Ds2013/InvalidOptionException.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace App\Ds2013\Exception;
+namespace App\Ds2013;
 
 use LogicException;
 

--- a/src/Ds2013/Molecule/Image/ImagePresenter.php
+++ b/src/Ds2013/Molecule/Image/ImagePresenter.php
@@ -2,7 +2,7 @@
 declare(strict_types = 1);
 namespace App\Ds2013\Molecule\Image;
 
-use App\Ds2013\Exception\InvalidOptionException;
+use App\Ds2013\InvalidOptionException;
 use App\Ds2013\Presenter;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
 use InvalidArgumentException;

--- a/src/Ds2013/Presenter.php
+++ b/src/Ds2013/Presenter.php
@@ -60,11 +60,15 @@ abstract class Presenter
 
     public function getOption($keyOption)
     {
-        if (isset($this->options[$keyOption])) {
+        if (array_key_exists($keyOption, $this->options)) {
             return $this->options[$keyOption];
         }
 
-        return null;
+        throw new InvalidOptionException(sprintf(
+            'Called getOption with an invalid value. Expected one of %s but got "%s"',
+            '"' . implode('", "', array_keys($this->options)) . '"',
+            $keyOption
+        ));
     }
 
     /**

--- a/tests/Ds2013/Molecule/Image/ImagePresenterTest.php
+++ b/tests/Ds2013/Molecule/Image/ImagePresenterTest.php
@@ -2,7 +2,7 @@
 declare(strict_types = 1);
 namespace Tests\App\Ds2013\Molecule\Image;
 
-use App\Ds2013\Exception\InvalidOptionException;
+use App\Ds2013\InvalidOptionException;
 use App\Ds2013\Molecule\Image\ImagePresenter;
 use PHPUnit\Framework\TestCase;
 use InvalidArgumentException;

--- a/tests/Ds2013/PresenterTest.php
+++ b/tests/Ds2013/PresenterTest.php
@@ -2,6 +2,7 @@
 declare(strict_types = 1);
 namespace Tests\App\Ds2013;
 
+use App\Ds2013\InvalidOptionException;
 use App\Ds2013\Presenter;
 use PHPUnit\Framework\TestCase;
 
@@ -37,7 +38,12 @@ class PresenterTest extends TestCase
             ['optionOne' => 1, 'optionTwo' => 2],
         ]);
 
-        $this->assertSame(null, $presenter->getOption('garbage'));
+        $this->expectException(InvalidOptionException::class);
+        $this->expectExceptionMessage(
+            'Called getOption with an invalid value. Expected one of "optionOne", "optionTwo" but got "garbage"'
+        );
+
+        $presenter->getOption('garbage');
     }
 
     public function testGetUniqueID()


### PR DESCRIPTION
Move the Exception class to the Ds2013 namespace as we're not expecting
having lots of different exceptions.