### PR TITLE
Schedules splitting

### DIFF
--- a/app/Resources/views/schedules/base.twig
+++ b/app/Resources/views/schedules/base.twig
@@ -25,6 +25,12 @@
 
     <div class="b-g-p br-box-page island--vertical">
         {{ ds2013('regionPick', page_presenter.service, app.request.attributes.get('date'), page_presenter.servicesInNetwork) }}
+
         {% block content %}{% endblock %}
+
+        {# Only show services list if there are more than two #}
+        {% if page_presenter.servicesInNetwork|length > 2 %}
+            {{ ds2013('networkServicesList', page_presenter.service, app.request.attributes.get('date'), page_presenter.servicesInNetwork) }}
+        {% endif %}
     </div>
 {% endblock %}

--- a/app/Resources/views/schedules/base.twig
+++ b/app/Resources/views/schedules/base.twig
@@ -16,13 +16,15 @@
             </time>
         </h1>
     </div>
+
     <nav class="schedule-nav-wrapper fixedsticky">
         <div id="schedule-daynav" class="centi br-box-highlight {{ page_presenter.service.isTv ? 'g-o-l daynav--tvschedule' : 'g-f-l' }}">
             {{ ds2013('dateList', page_presenter.startDate, page_presenter.service ) }}
         </div>
     </nav>
+
     <div class="b-g-p br-box-page island--vertical">
-        {{ ds2013('regionPick', page_presenter.service, page_presenter.startDate, page_presenter.servicesInNetwork) }}
+        {{ ds2013('regionPick', page_presenter.service, app.request.attributes.get('date'), page_presenter.servicesInNetwork) }}
         {% block content %}{% endblock %}
     </div>
 {% endblock %}

--- a/src/Ds2013/Page/Schedules/ByDayPage/schedules_by_day_page.html.twig
+++ b/src/Ds2013/Page/Schedules/ByDayPage/schedules_by_day_page.html.twig
@@ -43,7 +43,6 @@
         </li>
     {% endfor %}
 </ol>
-</div>
 
 {# If there is only 1 service in the network, it is the service we are currently viewing #}
 {% if schedules_by_day_page.servicesInNetwork|length >= 2 %}

--- a/src/Ds2013/Page/Schedules/ByDayPage/schedules_by_day_page.html.twig
+++ b/src/Ds2013/Page/Schedules/ByDayPage/schedules_by_day_page.html.twig
@@ -44,24 +44,3 @@
     {% endfor %}
 </ol>
 
-{# If there is only 1 service in the network, it is the service we are currently viewing #}
-{% if schedules_by_day_page.servicesInNetwork|length >= 2 %}
-    <div class="island--vertical">
-        <h2>{{ schedules_by_day_page.service.isTv ? tr('schedules_regional_note') : tr('schedules_regional_note_radio') }}</h2>
-        <div id="outlets" class="schedule-variant-outlets">
-            <ul class="list-unstyled columns columns--2@bpb2 columns--2@bpw delta">
-                {%- for service_in_network in schedules_by_day_page.servicesInNetwork -%}
-                    <li>
-                        {%- if service_in_network.pid == schedules_by_day_page.service.pid -%}
-                            <span class="box-link">{{ service_in_network.shortName }}</span>
-                        {%- else -%}
-                            <a href="{{ path('schedules_by_day', {'pid': service_in_network.pid, 'date': schedules_by_day_page.startDate|date('Y-m-d')}) }}"
-                               data-href-add-utcoffset="true"
-                               class="box-link">{{ service_in_network.shortName }}</a>
-                        {%- endif -%}
-                    </li>
-                {%- endfor -%}
-            </ul>
-        </div>
-    </div>
-{% endif %}

--- a/src/Ds2013/Page/Schedules/NetworkServicesList/NetworkServicesListPresenter.php
+++ b/src/Ds2013/Page/Schedules/NetworkServicesList/NetworkServicesListPresenter.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types = 1);
+namespace App\Ds2013\Page\Schedules\NetworkServicesList;
+
+use App\Ds2013\Presenter;
+use BBC\ProgrammesPagesService\Domain\Entity\Service;
+
+class NetworkServicesListPresenter extends Presenter
+{
+    /** @var Service */
+    private $service;
+
+    /** @var string|null */
+    private $date;
+
+    /** @var Service[] */
+    private $servicesInNetwork;
+
+    public function __construct(
+        Service $service,
+        ?string $date,
+        array $servicesInNetwork,
+        array $options = []
+    ) {
+        parent::__construct($options);
+        $this->service = $service;
+        $this->date = $date;
+        $this->servicesInNetwork = $servicesInNetwork;
+    }
+
+    public function getHeadingMessage()
+    {
+        return $this->service->isTv() ? 'schedules_regional_note' : 'schedules_regional_note_radio';
+    }
+
+    public function getService(): Service
+    {
+        return $this->service;
+    }
+
+    public function getDate(): ?string
+    {
+        return $this->date;
+    }
+
+    public function getServicesInNetwork(): array
+    {
+        return $this->servicesInNetwork;
+    }
+}

--- a/src/Ds2013/Page/Schedules/NetworkServicesList/network_services_list.html.twig
+++ b/src/Ds2013/Page/Schedules/NetworkServicesList/network_services_list.html.twig
@@ -1,0 +1,18 @@
+<div class="island--vertical">
+    <h2>{{ tr(network_services_list.headingMessage) }}</h2>
+    <div id="outlets" class="schedule-variant-outlets">
+        <ul class="list-unstyled columns columns--2@bpb2 columns--2@bpw delta">
+            {%- for service in network_services_list.servicesInNetwork -%}
+                <li>
+                    {%- if service.pid == network_services_list.service.pid -%}
+                        <span class="box-link">{{ service.shortName }}</span>
+                    {%- else -%}
+                        <a href="{{ path('schedules_by_day', {'pid': service.pid, 'date': network_services_list.date}) }}"
+                           data-href-add-utcoffset="true"
+                           class="box-link">{{ service.shortName }}</a>
+                    {%- endif -%}
+                </li>
+            {%- endfor -%}
+        </ul>
+    </div>
+</div>

--- a/src/Ds2013/Page/Schedules/RegionPick/region_pick.html.twig
+++ b/src/Ds2013/Page/Schedules/RegionPick/region_pick.html.twig
@@ -1,19 +1,23 @@
-{% if region_pick.servicesInNetwork|length > 0 %}
-    <div class="grid-wrapper">
-        <div class="grid 1/2@bpw2 1/2@bpe">
-            <p class="beta">
-                {{ tr('schedule_title', {'%1':region_pick.service.name})}}
-            </p>
-        </div>
+{% set title_classes = build_css_classes({
+    'grid': true,
+    '1/2@bpw2 1/2@bpe': region_pick.hasRegionPicker,
+}) %}
+
+<div class="grid-wrapper">
+    <div class="{{ title_classes }}">
+        <p class="beta">
+            {{ tr('schedule_title', {'%1':region_pick.serviceName}) }}
+        </p>
+    </div>
+    {% if region_pick.hasRegionPicker %}
          <div class="grid 1/2@bpw2 1/2@bpe">
             <div class="bpw-text--right">
-                {% if region_pick.twinService is empty %}
-                    {% set translationKey = region_pick.service.isTv ? 'schedules_regional' : 'schedules_regional_change' %}
-                    <a href="{{ path('schedules_home') }}" class="delta">{{ tr(translationKey, {'%1':region_pick.service.network.name }) }}</a>
-                {% else %}
-                    <a href="{{path('schedules_by_day', {'pid': region_pick.twinService.pid, 'date': region_pick.date.format('Y-m-d')})}}" class="delta">{{tr('schedules_regional_changeto', {'%1':region_pick.twin_service.name })}}</a>
-                {% endif %}
+                {% set link = region_pick.twinServicePid ? path('schedules_by_day', {
+                    'pid': region_pick.twinServicePid,
+                    'date': region_pick.date,
+                }) : '#outlets' %}
+                <a href="{{ link }}" class="delta">{{ tr(region_pick.linkMessage, {'%1': region_pick.linkName}) }}</a>
             </div>
          </div>
-    </div>
-{% endif %}
+    {% endif %}
+</div>

--- a/src/Ds2013/PresenterFactory.php
+++ b/src/Ds2013/PresenterFactory.php
@@ -7,6 +7,7 @@ use App\Ds2013\Molecule\Image\ImagePresenter;
 use App\Ds2013\Organism\Broadcast\BroadcastPresenter;
 use App\Ds2013\Organism\Programme\ProgrammePresenter;
 use App\Ds2013\Page\Schedules\ByDayPage\SchedulesByDayPagePresenter;
+use App\Ds2013\Page\Schedules\NetworkServicesList\NetworkServicesListPresenter;
 use App\Ds2013\Page\Schedules\RegionPick\RegionPickPresenter;
 use BBC\ProgrammesPagesService\Domain\Entity\Broadcast;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
@@ -113,6 +114,15 @@ class PresenterFactory
     /**
      * Page Presenters
      */
+    public function networkServicesListPresenter(
+        Service $service,
+        ?string $date,
+        array $servicesInNetwork,
+        array $options = []
+    ) {
+        return new NetworkServicesListPresenter($service, $date, $servicesInNetwork, $options);
+    }
+
     public function regionPickPresenter(
         Service $service,
         ?string $date,

--- a/src/Ds2013/PresenterFactory.php
+++ b/src/Ds2013/PresenterFactory.php
@@ -115,7 +115,7 @@ class PresenterFactory
      */
     public function regionPickPresenter(
         Service $service,
-        DateTimeImmutable $date,
+        ?string $date,
         array $servicesInNetwork,
         array $options = []
     ) {


### PR DESCRIPTION
I've had a play with extracting the services list into its own presenter, and along the way I've tidied up the region picker presenter too.

At this point there are things in the schedules page presenter that are never used within its own template, but are used in the base.html.twig and other templates in app/Resources. Personally I think this is odd, but we can have that discussion when I'm back in the office. Changes in this should be non-controversial, as it's mostly fixing and tidying things rather than changing how things get passed around