### PR TITLE
Presenter Template tests

### DIFF
--- a/tests/BaseTemplateTestCase.php
+++ b/tests/BaseTemplateTestCase.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types = 1);
+namespace Tests\App;
+
+use App\Ds2013\Presenter;
+use Symfony\Component\DomCrawler\Crawler;
+use Twig_Environment;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTemplateTestCase extends TestCase
+{
+    /** @var Twig_Environment */
+    static private $twig;
+
+    public static function setUpBeforeClass()
+    {
+        if (self::$twig === null) {
+            self::$twig = TwigEnvironmentProvider::twig();
+        }
+    }
+
+    /**
+     * Get a Dom Crawler populated with a given Twig template.
+     *
+     * @param string $name    The template name
+     * @param array  $context An array of parameters to pass to the template
+     *
+     * @return Crawler The Dom Crawler populated with the twig template
+     *
+     * @throws Twig_Error_Loader  When the template cannot be found
+     * @throws Twig_Error_Syntax  When an error occurred during compilation
+     * @throws Twig_Error_Runtime When an error occurred during rendering
+     */
+    protected function crawler(string $name, array $context = []): Crawler
+    {
+        return new Crawler(
+            self::$twig->loadTemplate($name)->render($context)
+        );
+    }
+
+    protected function presenterCrawler(Presenter $presenter): Crawler
+    {
+        return $this->crawler($presenter->getTemplatePath(), [
+            $presenter->getTemplateVariableName() => $presenter,
+        ]);
+    }
+
+    protected function assertSchemaOrgItem(string $expected, Crawler $node)
+    {
+        $this->assertEquals('http://schema.org/', $node->attr('vocab'));
+        $this->assertEquals($expected, $node->attr('typeof'));
+    }
+
+    protected function assertSchemaOrgPropertyAttr(string $expected, Crawler $node, string $property)
+    {
+        $this->assertEquals(
+            $expected,
+            $node->filter('[property="' . $property . '"]')->attr('content')
+        );
+    }
+}

--- a/tests/Ds2013/Organism/Broadcast/BroadcastTemplateTest.php
+++ b/tests/Ds2013/Organism/Broadcast/BroadcastTemplateTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types = 1);
+namespace Tests\App\Ds2013\Organism\Broadcast;
+
+use App\Ds2013\Organism\Broadcast\BroadcastPresenter;
+use BBC\ProgrammesPagesService\Domain\ApplicationTime;
+use Cake\Chronos\Chronos;
+use Tests\App\BaseTemplateTestCase;
+use BBC\ProgrammesPagesService\Domain\Entity\Broadcast;
+use BBC\ProgrammesPagesService\Domain\Entity\BroadcastGap;
+use BBC\ProgrammesPagesService\Domain\Entity\Episode;
+use BBC\ProgrammesPagesService\Domain\Entity\Service;
+use BBC\ProgrammesPagesService\Domain\Entity\Version;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+
+class BroadcastTemplateTest extends BaseTemplateTestCase
+{
+    public function testBroadcast()
+    {
+        $crawler = $this->presenterCrawler(new BroadcastPresenter(
+            $this->broadcast(
+                new Chronos('2015-01-01 06:00:00Z'),
+                new Chronos('2015-01-01 07:00:00Z')
+            )
+        ));
+
+        // No 'On air' box
+        $this->assertCount(0, $crawler->filter(".broadcast__live"));
+
+        // Contains a programme
+        $this->assertCount(1, $crawler->filter(".broadcast__programme .programme"));
+
+        // Schema.org properties
+        $broadcast = $crawler->filter(".broadcast");
+        $this->assertSchemaOrgItem('BroadcastEvent', $broadcast);
+        $this->assertSchemaOrgPropertyAttr('2015-01-01T06:00:00+00:00', $broadcast, 'startDate');
+        $this->assertSchemaOrgPropertyAttr('2015-01-01T07:00:00+00:00', $broadcast, 'endDate');
+    }
+
+    public function testBroadcastOnNow()
+    {
+        ApplicationTime::setTime((new Chronos('2015-01-01 06:30:00Z'))->timestamp);
+
+        $crawler = $this->presenterCrawler(new BroadcastPresenter(
+            $this->broadcast(
+                new Chronos('2015-01-01 06:00:00Z'),
+                new Chronos('2015-01-01 07:00:00Z')
+            )
+        ));
+
+        // 'On air' box
+        $this->assertEquals('On air', $crawler->filter(".broadcast__live")->text());
+
+        // Contains a programme
+        $this->assertCount(1, $crawler->filter(".broadcast__programme .programme"));
+    }
+
+    public function testBroadcastGap()
+    {
+        $mockService = $this->createMock(Service::class);
+        $mockService->method('getPid')->willReturn(new Pid('b0000002'));
+
+        $crawler = $this->presenterCrawler(new BroadcastPresenter(
+            new BroadcastGap(
+                $mockService,
+                new Chronos('2015-01-01 06:00:00Z'),
+                new Chronos('2015-01-01 07:00:00Z')
+            )
+        ));
+
+        $this->assertEquals('Off air', $crawler->filter(".broadcast__live")->text());
+        $this->assertEquals('Programmes will resume at 07:00', $crawler->filter(".broadcast__programme")->text());
+    }
+
+    private function broadcast(Chronos $startDate, Chronos $endDate): Broadcast
+    {
+        $mockEpisode = $this->createMock(Episode::class);
+        $mockEpisode->method('getPid')->willReturn(new Pid('b0000001'));
+
+        $mockService = $this->createMock(Service::class);
+        $mockService->method('getPid')->willReturn(new Pid('b0000002'));
+
+        return new Broadcast(
+            new Pid('b1234567'),
+            $this->createMock(Version::class),
+            $mockEpisode,
+            $mockService,
+            $startDate,
+            $endDate,
+            2700,
+            false,
+            false
+        );
+    }
+}

--- a/tests/TwigEnvironmentProvider.php
+++ b/tests/TwigEnvironmentProvider.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types = 1);
+namespace Tests\App;
+
+use App\Ds2013\PresenterFactory;
+use App\Twig\DesignSystemPresenterExtension;
+use App\Twig\GelIconExtension;
+use App\Twig\HtmlUtilitiesExtension;
+use RMP\Translate\TranslateFactory;
+use Symfony\Bridge\Twig\Extension\AssetExtension;
+use Symfony\Bridge\Twig\Extension\RoutingExtension;
+use Symfony\Component\Asset\Package;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Routing\Loader\YamlFileLoader;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+use Symfony\Component\Routing\RequestContext;
+use Twig_Environment;
+use Twig_Loader_Filesystem;
+
+class TwigEnvironmentProvider
+{
+    /** @var Twig_Environment */
+    static private $twig;
+
+    public static function twig(): Twig_Environment
+    {
+        if (self::$twig === null) {
+            self::$twig = self::buildTwig();
+        }
+
+        return self::$twig;
+    }
+
+    private static function buildTwig(): Twig_Environment
+    {
+        $loader = new Twig_Loader_Filesystem(__DIR__ . '/../app/Resources');
+        $loader->addPath(__DIR__ . '/../src/Ds2013', 'Ds2013');
+
+        $twig = new Twig_Environment($loader, ['strict_variables' => true]);
+
+        $translateFactory = new TranslateFactory([
+            'fallback_locale' => 'en_GB',
+            'cachepath' => __DIR__ . '/../tmp/cache/test/translations',
+            'domains' => ['programmes'],
+            'default_domain' => 'programmes',
+            'debug' => true,
+            'basepath' => __DIR__ . '/../app/Resources/translations',
+        ]);
+
+        $translate = $translateFactory->create('en_GB');
+
+        $assetPackages = new Packages(new Package(new EmptyVersionStrategy()));
+
+        $routeCollectionBuilder = new RouteCollectionBuilder(new YamlFileLoader(
+            new FileLocator([__DIR__ . '/../app/config'])
+        ));
+        $routeCollectionBuilder->import('routing.yml');
+
+        // Symfony extensions
+
+        $twig->addExtension(new AssetExtension($assetPackages));
+
+        $twig->addExtension(new RoutingExtension(new UrlGenerator(
+            $routeCollectionBuilder->build(),
+            new RequestContext()
+        )));
+
+        // Programmes extensions
+
+        $twig->addExtension(new DesignSystemPresenterExtension(
+            $translate,
+            new PresenterFactory($translate)
+        ));
+
+        $twig->addExtension(new GelIconExtension());
+
+        $twig->addExtension(new HtmlUtilitiesExtension($assetPackages));
+
+        return $twig;
+    }
+}


### PR DESCRIPTION
A framework for creating tests of presenter templates for when we want
to test the logic inside them. Most of the time we should be able to
test the Presenter directly, but there are some cases where we want to
assert on the output of view.

Test broadcast to see some examples.