### PR TITLE
Call the method for getting a localised date 'localDate'

### DIFF
--- a/app/Resources/views/schedules/by_day.html.twig
+++ b/app/Resources/views/schedules/by_day.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base_ds2013.html.twig' %}
 
 {%- block title -%}
-    {{ metaContext.titlePrefix() }} - {{ tr('schedules') }}, {{ broadcast_day_start|dateFormat('eeee d MMMM Y') }}
+    {{ metaContext.titlePrefix() }} - {{ tr('schedules') }}, {{ broadcast_day_start|localDate('eeee d MMMM Y') }}
 {%- endblock -%}
 
 {% block page_classes %}programmes-page text-base programmes-page--flush{% endblock %}
@@ -15,7 +15,7 @@
             </span>
         </span>
             <time class="date">
-                {{ broadcast_day_start|dateFormat('eeee d MMMM Y') }}
+                {{ broadcast_day_start|localDate('eeee d MMMM Y') }}
             </time>
         </h1>
     </div>

--- a/src/Ds2013/Molecule/DateList/date_list_item.html.twig
+++ b/src/Ds2013/Molecule/DateList/date_list_item.html.twig
@@ -32,10 +32,10 @@
 
     {% macro dateLines(datetime) %}
         <span class="date-list__item-line1">
-            {{ datetime.isToday ? tr('schedules_today') : datetime|dateFormat('eee') }}
+            {{ datetime.isToday ? tr('schedules_today') : datetime|localDate('eee') }}
         </span>
         <span class="date-list__item-line2">
-            {{ datetime|dateFormat('d MMM') }}
+            {{ datetime|localDate('d MMM') }}
         </span>
     {% endmacro %}
 {% endspaceless %}

--- a/src/Ds2013/TranslatableTrait.php
+++ b/src/Ds2013/TranslatableTrait.php
@@ -19,7 +19,7 @@ trait TranslatableTrait
      *
      * @return bool|string
      */
-    protected function dateFormat(DateTimeInterface $dateTime, string $format)
+    protected function localDate(DateTimeInterface $dateTime, string $format)
     {
         $formatter = IntlDateFormatter::create(
             $this->translate->getLocale(),

--- a/src/Twig/DesignSystemPresenterExtension.php
+++ b/src/Twig/DesignSystemPresenterExtension.php
@@ -43,7 +43,7 @@ class DesignSystemPresenterExtension extends Twig_Extension
     public function getFilters(): array
     {
         return [
-            new Twig_SimpleFilter('dateFormat', [$this, 'dateFormatWrapper']),
+            new Twig_SimpleFilter('localDate', [$this, 'localDateWrapper']),
         ];
     }
 
@@ -75,9 +75,9 @@ class DesignSystemPresenterExtension extends Twig_Extension
         return $this->tr($key, $substitutions, $numPlurals, $domain);
     }
 
-    public function dateFormatWrapper(DateTimeInterface $dateTime, string $format): string
+    public function localDateWrapper(DateTimeInterface $dateTime, string $format): string
     {
-        return $this->dateFormat($dateTime, $format);
+        return $this->localDate($dateTime, $format);
     }
 
     public function ds2013(


### PR DESCRIPTION
Previously it was dateFormat, but that does a really bad job at making
it clear that the function returns a localised date (and thus takes the format in a different style to the date() filter).