### PR TITLE
Create a routing_3rd_party.yml for routes that don't belong to our app

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -15,12 +15,6 @@ find_by_pid:
     defaults: { _controller: App\Controller\FindByPidController }
     requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
 
-atoz_list_all:
-    path: /programmes/a-z/all
-    # Redirect with a blank route throws a 404.
-    # We haven't rebuilt this route yet, but are referencing it in the app
-    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
-
 schedules_home:
     path: /schedules
     defaults: { _controller: App\Controller\SchedulesHomeController }
@@ -30,7 +24,13 @@ schedules_by_day:
     defaults: { _controller: App\Controller\SchedulesByDayController, date: null }
     requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}', date: '\d{4}-\d{2}-\d{2}' }
 
+# Labs routes, for testing things
+
 cloud_labs:
     path: /programmes/_cloudlabs{wildcard}
     defaults: { _controller: App\Controller\CloudLabsController }
     requirements: { wildcard: '^(/.*|$)' }
+
+# Include any 3rd party routes. This should be the last thing in the file
+_3rd_party:
+    resource: routing_3rd_party.yml

--- a/app/config/routing_3rd_party.yml
+++ b/app/config/routing_3rd_party.yml
@@ -1,0 +1,29 @@
+# This file shall contain routes used to build URLs that we want to reference
+# within the application, but are not part of the application. These routes
+# fall into one of two buckets:
+#
+# 1) A url to an external product, e.g. iplayer, iplayer radio
+# 2) A url to a /programme page we have not yet migrated. As we migrate pages,
+#    we shall move these routes into the main routing.yml.
+#
+# All routes in this file shall be configured with
+# defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
+# This means that the url can be routed by this application but throws a 404.
+
+### External Products
+
+iplayer_play:
+    path: /iplayer/{pid}
+    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
+    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
+
+iplayer_live:
+    path: /iplayer/live/{sid}
+    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
+    requirements: { sid: '[0-9a-z_]{1,}' }
+
+### /programmes v2
+
+atoz_list_all:
+    path: /programmes/a-z/all
+    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }

--- a/src/Ds2013/Organism/Programme/SubPresenters/ProgrammeImagePresenter.php
+++ b/src/Ds2013/Organism/Programme/SubPresenters/ProgrammeImagePresenter.php
@@ -79,11 +79,15 @@ class ProgrammeImagePresenter extends ProgrammePresenterBase
             return '';
         }
 
+        $routeName = 'iplayer_play';
+        $routeArguments = ['pid' => $this->programme->getPid()];
+
         if ($this->programme->isRadio() || $this->programme->isAudio() || $this->programme instanceof Clip) {
             // Radio programme. Link to programme page for now.
-            return $this->router->generate('find_by_pid', ['pid' => $this->programme->getPid()]) . '#play';
+            $routeName = 'find_by_pid';
+            $routeArguments['_fragment'] = 'play';
         }
-        // TV Episode @TODO this needs to be more sophistimicated
-        return '/iplayer/' . urlencode((string) $this->programme->getPid());
+
+        return $this->router->generate($routeName, $routeArguments);
     }
 }

--- a/tests/Ds2013/Organism/Programme/SubPresenters/ProgrammeImagePresenterTest.php
+++ b/tests/Ds2013/Organism/Programme/SubPresenters/ProgrammeImagePresenterTest.php
@@ -10,18 +10,28 @@ use BBC\ProgrammesPagesService\Domain\Entity\Episode;
 use BBC\ProgrammesPagesService\Domain\Entity\ProgrammeItem;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouteCollectionBuilder;
 use Tests\App\TwigEnvironmentProvider;
 
 class ProgrammeImagePresenterTest extends TestCase
 {
-    private $mockRouter;
+    private $router;
 
     private $mockTranslationsHelper;
 
     public function setUp()
     {
-        $this->mockRouter = $this->createMock(UrlGeneratorInterface::class);
+        $routeCollectionBuilder = new RouteCollectionBuilder();
+        $routeCollectionBuilder->add('/programmes/{pid}', '', 'find_by_pid');
+        $routeCollectionBuilder->add('/iplayer/{pid}', '', 'iplayer_play');
+
+        $this->router = new UrlGenerator(
+            $routeCollectionBuilder->build(),
+            new RequestContext()
+        );
+
         $this->mockTranslationsHelper = $this->createMock(PlayTranslationsHelper::class);
     }
 
@@ -35,7 +45,7 @@ class ProgrammeImagePresenterTest extends TestCase
             ->method('isRadio')
             ->willReturn($isRadio);
         $programmeImagePresenter = new ProgrammeImagePresenter(
-            $this->mockRouter,
+            $this->router,
             $this->mockTranslationsHelper,
             $programme
         );
@@ -55,7 +65,7 @@ class ProgrammeImagePresenterTest extends TestCase
     {
         $programmeItem = $this->playbackUrlProgramme(Episode::class, 'b0000002', false, false);
         $programmeImagePresenter = new ProgrammeImagePresenter(
-            $this->mockRouter,
+            $this->router,
             $this->mockTranslationsHelper,
             $programmeItem
         );
@@ -67,15 +77,8 @@ class ProgrammeImagePresenterTest extends TestCase
      */
     public function testGetPlaybackUrlProgrammes(ProgrammeItem $programmeItem, $expectedUrl)
     {
-        $this->mockRouter->expects($this->once())
-            ->method('generate')
-            ->with(
-                'find_by_pid',
-                ['pid' => (string) $programmeItem->getPid()]
-            )->willReturn('/programmes/' . (string) $programmeItem->getPid());
-
         $programmeImagePresenter = new ProgrammeImagePresenter(
-            $this->mockRouter,
+            $this->router,
             $this->mockTranslationsHelper,
             $programmeItem
         );


### PR DESCRIPTION
We should put iplayer routes into there, and use url builders, rather
than generating urls on the fly