### PR TITLE
Fallback to a default branding, instead of 500ing

### DIFF
--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -5,25 +5,35 @@ namespace App\Controller;
 
 use App\Translate\TranslateProvider;
 use App\ValueObject\MetaContext;
+use BBC\BrandingClient\Branding;
 use BBC\BrandingClient\BrandingClient;
+use BBC\BrandingClient\BrandingException;
 use BBC\BrandingClient\OrbitClient;
 use BBC\ProgrammesPagesService\Domain\Entity\Network;
 use BBC\ProgrammesPagesService\Domain\Entity\Programme;
 use BBC\ProgrammesPagesService\Domain\Entity\Service;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use App\Twig\DesignSystemPresenterExtension;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 abstract class BaseController extends AbstractController
 {
     private $brandingId = 'br-00001';
 
+    /**
+     * Used in case a page requests a BrandingID that does not exist.
+     * This may be changed depending upon the $context
+     */
+    private $fallbackBrandingId = 'br-00001';
+
     private $context;
 
     public static function getSubscribedServices()
     {
         return array_merge(parent::getSubscribedServices(), [
+            'logger' => LoggerInterface::class,
             BrandingClient::class,
             OrbitClient::class,
             TranslateProvider::class,
@@ -32,7 +42,7 @@ abstract class BaseController extends AbstractController
 
     protected function getCanonicalUrl(): string
     {
-        $requestAttributes = $this->container->get('request_stack')->getCurrentRequest()->attributes;
+        $requestAttributes = $this->request()->attributes;
         return $this->generateUrl(
             $requestAttributes->get('_route'),
             $requestAttributes->get('_route_params'),
@@ -49,22 +59,23 @@ abstract class BaseController extends AbstractController
     {
         $this->context = $context;
 
+        // br-00002 is the default 'Programme Variant' - use that when we're
+        // displaying programme/group/service pages.
+        // TODO instanceof Group should use the brandingId from their options
+        // and use br-00002 as a fallback (same as instanceof Programme), when
+        // we create those domain models
         if ($context instanceof Programme || $context instanceof Network) {
             $this->setBrandingId($context->getOption('branding_id'));
+            $this->fallbackBrandingId = 'br-00002';
         } elseif ($context instanceof Service) {
             $this->setBrandingId($context->getNetwork()->getOption('branding_id'));
+            $this->fallbackBrandingId = 'br-00002';
         }
     }
 
     protected function renderWithChrome(string $view, array $parameters = [], Response $response = null)
     {
-        // Using $_GET is ugly, work out a way to get to the Request object
-        // without having to pass it around everywhere
-        $brandingClient = $this->container->get(BrandingClient::class);
-        $branding = $brandingClient->getContent(
-            $this->brandingId,
-            $_GET[$brandingClient::PREVIEW_PARAM] ?? null
-        );
+        $branding = $this->requestBranding();
 
         // We only need to change the translation language if it is different
         // to the language the translation extension was initially created with
@@ -88,5 +99,48 @@ abstract class BaseController extends AbstractController
         ], $parameters);
 
         return $this->render($view, $parameters, $response);
+    }
+
+    private function requestBranding(): Branding
+    {
+        $brandingClient = $this->container->get(BrandingClient::class);
+        $previewId = $this->request()->query->get($brandingClient::PREVIEW_PARAM, null);
+        $usePreview = !is_null($previewId);
+
+        try {
+            $this->logger()->info(
+                'Using BrandingID "{0}"' . ($usePreview ? ', but overridden previewing theme version "{1}"' : ''),
+                $usePreview ? [$this->brandingId, $previewId] : [$this->brandingId]
+            );
+
+            $branding = $brandingClient->getContent(
+                $this->brandingId,
+                $previewId
+            );
+        } catch (BrandingException $e) {
+            // Could not find that branding id (or preview id), someone probably
+            // mistyped it. Use a default branding instead of blowing up.
+
+            $this->logger()->warning(
+                'Requested BrandingID "{0}"' . ($usePreview ? ', but overridden previewing theme version "{2}"' : '') .
+                ' but it was not found. Using "{1}" as a fallback',
+                $usePreview ? [$this->brandingId, $this->fallbackBrandingId, $previewId] : [$this->brandingId, $this->fallbackBrandingId]
+            );
+
+            $this->setBrandingId($this->fallbackBrandingId);
+            $branding = $brandingClient->getContent($this->brandingId, null);
+        }
+
+        return $branding;
+    }
+
+    private function logger(): LoggerInterface
+    {
+        return $this->container->get('logger');
+    }
+
+    private function request(): Request
+    {
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 }


### PR DESCRIPTION
Use a default branding of br-00001 or br-00002 if you end up requesting
a branding ID that does not exist.

I've also worked out how to not use $_GET for the preview parameter -
get the current request from the request_stack that comes from the
container.