### PR TITLE
Link to the http version of iplayer episode pages

### DIFF
--- a/app/config/routing_3rd_party.yml
+++ b/app/config/routing_3rd_party.yml
@@ -16,6 +16,7 @@ iplayer_play:
     path: /iplayer/episode/{pid}
     defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
     requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
+    schemes: [http]
 
 iplayer_live:
     path: /iplayer/live/{sid}

--- a/src/Ds2013/Organism/Programme/SubPresenters/ProgrammeImagePresenter.php
+++ b/src/Ds2013/Organism/Programme/SubPresenters/ProgrammeImagePresenter.php
@@ -89,6 +89,6 @@ class ProgrammeImagePresenter extends ProgrammePresenterBase
             $routeArguments['_fragment'] = 'play';
         }
 
-        return $this->router->generate($routeName, $routeArguments);
+        return $this->router->generate($routeName, $routeArguments, UrlGeneratorInterface::ABSOLUTE_URL);
     }
 }

--- a/src/Ds2013/Organism/Programme/SubPresenters/ProgrammeTitlePresenter.php
+++ b/src/Ds2013/Organism/Programme/SubPresenters/ProgrammeTitlePresenter.php
@@ -49,7 +49,7 @@ class ProgrammeTitlePresenter extends ProgrammePresenterBase
     public function getTitleLinkUrl(): string
     {
         // Link to iplayer/podcasts will be added here later
-        return $this->router->generate('find_by_pid', ['pid' => $this->programme->getPid()]);
+        return $this->router->generate('find_by_pid', ['pid' => $this->programme->getPid()], UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     public function getMainTitleProgramme(): Programme

--- a/src/Ds2013/Organism/Programme/SubPresenters/programme_image.html.twig
+++ b/src/Ds2013/Organism/Programme/SubPresenters/programme_image.html.twig
@@ -33,7 +33,7 @@
                         {% if programme_image.isEpisode %}
                             <div property="{{ rdfa_schema_media_type(programme_image.programme) }}" typeof="{{ rdfa_schema_mediaobject_typeof(programme_image.programme) }}">
                                 <a property="url"
-                                   resource="http://www.bbc.co.uk{{ programme_image.playbackUrl }}"
+                                   resource="{{ programme_image.playbackUrl }}"
                                    href="{{ programme_image.playbackUrl }}"
                                    class="programme__availability programme__player iplayer-icon--container"
                                    title="{{ programme_image.availabilityInWords }}"

--- a/src/Ds2013/Organism/Programme/SubPresenters/programme_title.html.twig
+++ b/src/Ds2013/Organism/Programme/SubPresenters/programme_title.html.twig
@@ -2,7 +2,7 @@
 {% set title_tag = programme_title.option('title_tag') %}
 {% spaceless %}
     <{{ title_tag }} class="programme__titles">
-        <a property="url" href="{{ programme_title.titleLinkUrl }}" resource="http://www.bbc.co.uk{{ programme_title.titleLinkUrl }}" class="br-blocklink__link block-link__target" data-linktrack="programmeobjectlink=title">
+        <a property="url" href="{{ programme_title.titleLinkUrl }}" resource="{{ programme_title.titleLinkUrl }}" class="br-blocklink__link block-link__target" data-linktrack="programmeobjectlink=title">
             <span class="programme__title {{ programme_title.option('title_classes') }}">
                 {{ self.render_title(programme_title.mainTitleProgramme, programme_title) }}
             </span>

--- a/tests/Ds2013/Organism/Programme/ProgrammeTemplateTest.php
+++ b/tests/Ds2013/Organism/Programme/ProgrammeTemplateTest.php
@@ -48,7 +48,7 @@ class ProgrammeTemplateTest extends BaseTemplateTestCase
         $this->assertHasClasses('programme__overlay programme__overlay--available', $overlayDiv, 'Overlay container classes');
 
         $overlayLink = $overlayDiv->filterXPath('//a')->first();
-        $this->assertEquals('/iplayer/episode/p0000001', $overlayLink->attr('href'));
+        $this->assertEquals('http://localhost/iplayer/episode/p0000001', $overlayLink->attr('href'));
         $this->assertStringStartsWith('30 days left to watch', $overlayLink->attr('title'));
         $this->assertEquals('programmeobjectlink=cta', $overlayLink->attr('data-linktrack'));
         $this->assertHasClasses('iplayer-icon--container', $overlayLink, 'Iplayer overlay link has icon classes');
@@ -61,7 +61,7 @@ class ProgrammeTemplateTest extends BaseTemplateTestCase
 
         // Test main link target
         $targetLink = $crawler->filter('.block-link__target');
-        $this->assertEquals('/programmes/p0000001', $targetLink->attr('href'), 'Main block-link target URL');
+        $this->assertEquals('http://localhost/programmes/p0000001', $targetLink->attr('href'), 'Main block-link target URL');
         $this->assertEquals('programmeobjectlink=title', $targetLink->attr('data-linktrack'), 'Main block link tracking');
 
         // Test titles
@@ -115,7 +115,7 @@ class ProgrammeTemplateTest extends BaseTemplateTestCase
         $this->assertHasClasses('programme__overlay programme__overlay--available', $overlayDiv, 'Overlay container classes');
 
         $overlayLink = $overlayDiv->filterXPath('//a')->first();
-        $this->assertEquals('/programmes/b0849ccf#play', $overlayLink->attr('href'));
+        $this->assertEquals('http://localhost/programmes/b0849ccf#play', $overlayLink->attr('href'));
         $this->assertStringStartsWith('Listen now', $overlayLink->attr('title'));
         $this->assertEquals('programmeobjectlink=cta', $overlayLink->attr('data-linktrack'));
         $this->assertHasClasses('iplayer-icon--container', $overlayLink, 'Iplayer overlay link has icon classes');
@@ -128,7 +128,7 @@ class ProgrammeTemplateTest extends BaseTemplateTestCase
 
         // Test main link target
         $targetLink = $crawler->filter('.block-link__target');
-        $this->assertEquals('/programmes/b0849ccf', $targetLink->attr('href'), 'Main block-link target URL');
+        $this->assertEquals('http://localhost/programmes/b0849ccf', $targetLink->attr('href'), 'Main block-link target URL');
         $this->assertEquals('programmeobjectlink=title', $targetLink->attr('data-linktrack'), 'Main block link tracking');
 
         // Test titles

--- a/tests/Ds2013/Organism/Programme/SubPresenters/ProgrammeImagePresenterTest.php
+++ b/tests/Ds2013/Organism/Programme/SubPresenters/ProgrammeImagePresenterTest.php
@@ -25,7 +25,7 @@ class ProgrammeImagePresenterTest extends TestCase
     {
         $routeCollectionBuilder = new RouteCollectionBuilder();
         $routeCollectionBuilder->add('/programmes/{pid}', '', 'find_by_pid');
-        $routeCollectionBuilder->add('/iplayer/{pid}', '', 'iplayer_play');
+        $routeCollectionBuilder->add('/iplayer/episode/{pid}', '', 'iplayer_play');
 
         $this->router = new UrlGenerator(
             $routeCollectionBuilder->build(),
@@ -69,7 +69,7 @@ class ProgrammeImagePresenterTest extends TestCase
             $this->mockTranslationsHelper,
             $programmeItem
         );
-        $this->assertEquals('/iplayer/b0000002', $programmeImagePresenter->getPlaybackUrl());
+        $this->assertEquals('http://localhost/iplayer/episode/b0000002', $programmeImagePresenter->getPlaybackUrl());
     }
 
     /**
@@ -90,19 +90,19 @@ class ProgrammeImagePresenterTest extends TestCase
         return [
             [// Radio episode
                 $this->playbackUrlProgramme(Episode::class, 'b0000001', true, true),
-                '/programmes/b0000001#play', // Expected URL for programme
+                'http://localhost/programmes/b0000001#play', // Expected URL for programme
             ],
             [// Audio episode
                 $this->playbackUrlProgramme(Episode::class, 'b0000001', false, true),
-                '/programmes/b0000001#play', // Expected URL for programme
+                'http://localhost/programmes/b0000001#play', // Expected URL for programme
             ],
             [// Radio clip
                 $this->playbackUrlProgramme(Clip::class, 'p0000003', true, true),
-                '/programmes/p0000003#play', // Expected URL for programme
+                'http://localhost/programmes/p0000003#play', // Expected URL for programme
             ],
             [// TV Clip
                 $this->playbackUrlProgramme(Clip::class, 'p0000003', false, false),
-                '/programmes/p0000003#play', // Expected URL for programme
+                'http://localhost/programmes/p0000003#play', // Expected URL for programme
             ],
         ];
     }


### PR DESCRIPTION
Ensure we always use absolute URLs for image and title links in the
programme object as they may link to iplayer which is http only (for now)