### PR TITLE
Add BrandingPlaceHolderResolver

### DIFF
--- a/app/config/routing_3rd_party.yml
+++ b/app/config/routing_3rd_party.yml
@@ -30,3 +30,21 @@ atoz_list_all:
     path: /programmes/a-z/all
     defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
     schemes: [http]
+
+programme_episodes:
+    path: /programmes/{pid}/episodes
+    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
+    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
+    schemes: [http]
+
+programme_clips:
+    path: /programmes/{pid}/clips
+    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
+    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
+    schemes: [http]
+
+programme_galleries:
+    path: /programmes/{pid}/galleries
+    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
+    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
+    schemes: [http]

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -14,7 +14,7 @@ services:
 
     # Autowire all necessary Twig, Argument resolver and Event Subscriber services
     App\:
-        resource: '../../src/{ArgumentResolver,EventSubscriber,Twig}'
+        resource: '../../src/{ArgumentResolver,Branding,EventSubscriber,Twig}'
 
     # Autowire controllers in the DI layer and make them public
     App\Controller\:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-intl": "*",
         "ext-redis": "*",
         "bbc-rmp/translate": "^1.8",
-        "bbc/branding-client": "^2.0.3",
+        "bbc/branding-client": "^2.0.4",
         "bbc/gel-iconography-assets": "^1.2",
         "bbc/programmes-pages-service": "^2.4.2",
         "cakephp/chronos": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8200b1ee3ef9a353e006ce05a209fa6b",
+    "content-hash": "24fbebc9aa7b4dec74edbd0f8a081500",
     "packages": [
         {
             "name": "bbc-rmp/translate",
@@ -54,16 +54,16 @@
         },
         {
             "name": "bbc/branding-client",
-            "version": "v2.0.3",
+            "version": "v2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bbc/branding-client.git",
-                "reference": "ba33c4e2c97a1cb37ae958b737aad909bc99977a"
+                "reference": "34402ee3a7a79d1348071b6d352a904a5fd7a947"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bbc/branding-client/zipball/ba33c4e2c97a1cb37ae958b737aad909bc99977a",
-                "reference": "ba33c4e2c97a1cb37ae958b737aad909bc99977a",
+                "url": "https://api.github.com/repos/bbc/branding-client/zipball/34402ee3a7a79d1348071b6d352a904a5fd7a947",
+                "reference": "34402ee3a7a79d1348071b6d352a904a5fd7a947",
                 "shasum": ""
             },
             "require": {
@@ -93,10 +93,10 @@
             ],
             "description": "PHP Branding client",
             "support": {
-                "source": "https://github.com/bbc/branding-client/tree/v2.0.3",
+                "source": "https://github.com/bbc/branding-client/tree/v2.0.4",
                 "issues": "https://github.com/bbc/branding-client/issues"
             },
-            "time": "2017-07-06T17:03:37+00:00"
+            "time": "2017-07-18T16:24:12+00:00"
         },
         {
             "name": "bbc/doctrine-extensions",

--- a/src/Branding/BrandingPlaceholderResolver.php
+++ b/src/Branding/BrandingPlaceholderResolver.php
@@ -1,0 +1,175 @@
+<?php
+declare(strict_types = 1);
+namespace App\Branding;
+
+use App\Translate\TranslateProvider;
+use BBC\BrandingClient\Branding;
+use BBC\ProgrammesPagesService\Domain\Entity\Episode;
+use BBC\ProgrammesPagesService\Domain\Entity\Programme;
+use BBC\ProgrammesPagesService\Domain\Entity\ProgrammeContainer;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Consider "I'm Sorry I Haven't a Clue" - it is a Radio 4 programme. Radio
+ * programmes tend not to have bespoke per-brand theming, instead they inherit
+ * their theme from their Service (in this case Radio 4). This however poses
+ * a small problem - if we display the Service theme, how shall we show the
+ * correct per-programme Title and Navigation?
+ *
+ * This is solved by the Branding Tool outputting templates that contain
+ * placeholder sections such as  <!--BRANDING_PLACEHOLDER_TITLE--> and
+ * <!--BRANDING_PLACEHOLDER_NAV--> when there is not programme set.
+ *
+ * This takes a Branding instance that contains those placeholders and a
+ * "context" and replaces those placeholders with a title and default
+ * navigation, based up the contents of the context.
+ */
+class BrandingPlaceholderResolver
+{
+    private const PLACEHOLDER_TITLE = '<!--BRANDING_PLACEHOLDER_TITLE-->';
+    private const PLACEHOLDER_NAV = '<!--BRANDING_PLACEHOLDER_NAV-->';
+    private const PLACEHOLDER_SPONSOR = '<!--BRANDING_PLACEHOLDER_SPONSOR-->';
+
+    /** @var UrlGeneratorInterface */
+    private $router;
+
+    /** @var TranslateProvider */
+    private $translateProvider;
+
+    public function __construct(
+        UrlGeneratorInterface $router,
+        TranslateProvider $translateProvider
+    ) {
+        $this->router = $router;
+        $this->translateProvider = $translateProvider;
+    }
+
+    public function resolve(Branding $branding, $context): Branding
+    {
+        // If the context is not a Programme or Group then don't attempt to resolve
+        if (!($context instanceof Programme /*|| $context instanceof Group*/)) {
+            return $branding;
+        }
+
+        // Currently placeholders only exist in the bodyFirst section
+        return new Branding(
+            $branding->getHead(),
+            $this->resolvePlaceholders($branding, $context, $branding->getBodyFirst()),
+            $branding->getBodyLast(),
+            $branding->getColours(),
+            $branding->getOptions()
+        );
+    }
+
+    private function resolvePlaceholders(Branding $branding, $context, string $haystack)
+    {
+        // Check if the placeholder is present in the haystack, before
+        // attempting the replace to avoid doing extra work building the
+        // replacement text, if there is nothing to replace.
+
+        // Title
+        if (strpos($haystack, self::PLACEHOLDER_TITLE) !== 0) {
+            $haystack = str_replace(
+                self::PLACEHOLDER_TITLE,
+                $this->buildTitle($context),
+                $haystack
+            );
+        }
+
+        // Navigation
+        if (strpos($haystack, self::PLACEHOLDER_NAV) !== 0) {
+            $haystack = str_replace(
+                self::PLACEHOLDER_NAV,
+                $this->buildNav($context, $branding),
+                $haystack
+            );
+        }
+
+        // Sponsor
+        if (strpos($haystack, self::PLACEHOLDER_SPONSOR) !== 0) {
+            $haystack = str_replace(
+                self::PLACEHOLDER_SPONSOR,
+                $this->buildSponsor($context),
+                $haystack
+            );
+        }
+
+        return $haystack;
+    }
+
+    private function buildTitle($context): string
+    {
+        return sprintf(
+            '<a href="%s">%s</a>',
+            $this->router->generate('find_by_pid', ['pid' => $context->getTleo()->getPid()]),
+            $context->getTleo()->getTitle()
+        );
+    }
+
+    private function buildNav($context, Branding $branding): string
+    {
+        $translate = $this->translateProvider->getTranslate();
+
+        // We've already asserted that $context is a Programme or a Group
+        $tleo = $context->getTleo();
+        $navItems = [];
+
+        $hasEpisodes = false;
+        $hasClips = false;
+        $hasGalleries = false;
+
+        // Home link is always present
+        $navItems[] = $branding->buildNavItem(
+            $translate->translate('home'),
+            $this->router->generate('find_by_pid', ['pid' => $tleo->getPid()]),
+            'nav_home'
+        );
+
+        if ($tleo instanceof ProgrammeContainer) {
+            $hasEpisodes = $tleo->getAggregatedEpisodesCount() > 0;
+        }
+
+        if ($tleo instanceof ProgrammeContainer || $tleo instanceof Episode) {
+            $hasClips = $tleo->getAvailableClipsCount() > 0;
+            $hasGalleries = $tleo->getAvailableGalleriesCount() > 0;
+        }
+
+        // TODO handle instanceof Group
+        // At the time of writing Group models have not yet been implemented
+
+        // Episodes link
+        if ($tleo && $hasEpisodes) {
+            $navItems[] = $branding->buildNavItem(
+                $translate->translate('episodes'),
+                $this->router->generate('programme_episodes', ['pid' => $tleo->getPid()]),
+                'nav_episodes'
+            );
+        }
+
+        // Clips link
+        if ($tleo && $hasClips) {
+            $navItems[] = $branding->buildNavItem(
+                $translate->translate('clips'),
+                $this->router->generate('programme_clips', ['pid' => $tleo->getPid()]),
+                'nav_clips'
+            );
+        }
+
+        // Galleries link
+        if ($tleo && $hasGalleries) {
+            $navItems[] = $branding->buildNavItem(
+                $translate->translate('galleries'),
+                $this->router->generate('programme_galleries', ['pid' => $tleo->getPid()]),
+                'nav_galleries'
+            );
+        }
+
+        return implode('', $navItems);
+    }
+
+    private function buildSponsor($context): string
+    {
+        // TODO
+        return '';
+    }
+}

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace App\Controller;
 
+use App\Branding\BrandingPlaceholderResolver;
 use App\Translate\TranslateProvider;
 use App\ValueObject\MetaContext;
 use BBC\BrandingClient\Branding;
@@ -37,6 +38,7 @@ abstract class BaseController extends AbstractController
         return array_merge(parent::getSubscribedServices(), [
             'logger' => LoggerInterface::class,
             BrandingClient::class,
+            BrandingPlaceholderResolver::class,
             OrbitClient::class,
             TranslateProvider::class,
         ]);
@@ -162,6 +164,14 @@ abstract class BaseController extends AbstractController
 
             $this->setBrandingId($this->fallbackBrandingId);
             $branding = $brandingClient->getContent($this->brandingId, null);
+        }
+
+        // Resolve branding placeholders
+        if ($this->context) {
+            $branding = $this->container->get(BrandingPlaceholderResolver::class)->resolve(
+                $branding,
+                $this->context
+            );
         }
 
         return $branding;

--- a/tests/Branding/BrandingPlaceholderResolverTest.php
+++ b/tests/Branding/BrandingPlaceholderResolverTest.php
@@ -1,0 +1,165 @@
+<?php
+declare(strict_types = 1);
+namespace Tests\App\Branding;
+
+use App\Branding\BrandingPlaceholderResolver;
+use App\Translate\TranslateProvider;
+use BBC\BrandingClient\Branding;
+use BBC\ProgrammesPagesService\Domain\Entity\Episode;
+use BBC\ProgrammesPagesService\Domain\Entity\ProgrammeContainer;
+use BBC\ProgrammesPagesService\Domain\Entity\Service;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use RMP\Translate\Translate;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+use PHPUnit\Framework\TestCase;
+
+class BrandingPlaceholderResolverTest extends TestCase
+{
+    private $resolver;
+
+    public function setUp()
+    {
+        $routeCollectionBuilder = new RouteCollectionBuilder();
+        $routeCollectionBuilder->add('/programmes/{pid}', '', 'find_by_pid');
+        $routeCollectionBuilder->add('/programmes/{pid}/episodes', '', 'programme_episodes');
+        $routeCollectionBuilder->add('/programmes/{pid}/clips', '', 'programme_clips');
+        $routeCollectionBuilder->add('/programmes/{pid}/galleries', '', 'programme_galleries');
+
+        $router = new UrlGenerator(
+            $routeCollectionBuilder->build(),
+            new RequestContext()
+        );
+
+        $translate = $this->createMock(Translate::class);
+
+        $translate->method('translate')
+            ->will($this->returnArgument(0));
+
+        $translateProvider = $this->createMock(TranslateProvider::class);
+        $translateProvider->method('getTranslate')->willReturn($translate);
+
+        $this->resolver = new BrandingPlaceholderResolver($router, $translateProvider);
+    }
+
+    public function testContextIsNull()
+    {
+        $branding = $this->branding();
+        $context = null;
+        $this->assertSame($branding, $this->resolver->resolve($branding, $context));
+    }
+
+    public function testContextIsUnknownClass()
+    {
+        $branding = $this->branding();
+        $context = $this->createMock(Service::class);
+        $this->assertSame($branding, $this->resolver->resolve($branding, $context));
+    }
+
+    public function testContextTleoIsProgrammeContainerWithoutEpisodesClipsAndGalleries()
+    {
+        $resolvedBranding = $this->resolver->resolve(
+            $this->branding(),
+            $this->buildContext(ProgrammeContainer::class, 0, 0, 0)
+        );
+
+        $this->assertContains('<a href="/programmes/b0000001">MyTitle</a>', $resolvedBranding->getBodyFirst());
+
+        // Only has a Home link
+        $this->assertContains(
+            '<li class="br-nav__item"><a class="br-nav__link" href="/programmes/b0000001" data-linktrack="nav_home">home</a></li>',
+            $resolvedBranding->getBodyFirst()
+        );
+    }
+
+    public function testContextTleoIsProgrammeContainerWithEpisodesClipsAndGalleries()
+    {
+        $resolvedBranding = $this->resolver->resolve(
+            $this->branding(),
+            $this->buildContext(ProgrammeContainer::class, 1, 1, 1)
+        );
+
+        $this->assertContains('<a href="/programmes/b0000001">MyTitle</a>', $resolvedBranding->getBodyFirst());
+
+        $this->assertContains(
+            '<li class="br-nav__item"><a class="br-nav__link" href="/programmes/b0000001" data-linktrack="nav_home">home</a></li>' .
+            '<li class="br-nav__item"><a class="br-nav__link" href="/programmes/b0000001/episodes" data-linktrack="nav_episodes">episodes</a></li>' .
+            '<li class="br-nav__item"><a class="br-nav__link" href="/programmes/b0000001/clips" data-linktrack="nav_clips">clips</a></li>' .
+            '<li class="br-nav__item"><a class="br-nav__link" href="/programmes/b0000001/galleries" data-linktrack="nav_galleries">galleries</a></li>',
+            $resolvedBranding->getBodyFirst()
+        );
+    }
+
+
+    public function testContextTleoIsEpisodeWithOnlyClips()
+    {
+        $resolvedBranding = $this->resolver->resolve(
+            $this->branding(),
+            $this->buildContext(Episode::class, 0, 1, 0)
+        );
+
+        $this->assertContains('<a href="/programmes/b0000001">MyTitle</a>', $resolvedBranding->getBodyFirst());
+
+        $this->assertContains(
+            '<li class="br-nav__item"><a class="br-nav__link" href="/programmes/b0000001" data-linktrack="nav_home">home</a></li>' .
+            '<li class="br-nav__item"><a class="br-nav__link" href="/programmes/b0000001/clips" data-linktrack="nav_clips">clips</a></li>',
+            $resolvedBranding->getBodyFirst()
+        );
+    }
+
+    public function testContextTleoIsEpisodeWithOnlyGalleries()
+    {
+        $resolvedBranding = $this->resolver->resolve(
+            $this->branding(),
+            $this->buildContext(Episode::class, 0, 0, 1)
+        );
+
+        $this->assertContains('<a href="/programmes/b0000001">MyTitle</a>', $resolvedBranding->getBodyFirst());
+
+        $this->assertContains(
+            '<li class="br-nav__item"><a class="br-nav__link" href="/programmes/b0000001" data-linktrack="nav_home">home</a></li>' .
+            '<li class="br-nav__item"><a class="br-nav__link" href="/programmes/b0000001/galleries" data-linktrack="nav_galleries">galleries</a></li>',
+            $resolvedBranding->getBodyFirst()
+        );
+    }
+
+    private function branding()
+    {
+        return new Branding(
+            '<branding-head/>',
+            '<branding-bodyfirst><!--BRANDING_PLACEHOLDER_TITLE-->||<!--BRANDING_PLACEHOLDER_NAV-->||<!--BRANDING_PLACEHOLDER_SPONSOR--></branding-bodyfirst>',
+            '<branding-bodylast/>',
+            ['body' => ['bg' => '#eeeeee']],
+            []
+        );
+    }
+
+    private function buildContext(
+        string $tleoClassName,
+        int $episodesCount = 0,
+        int $clipsCount = 0,
+        int $galleriesCount = 0
+    ) {
+        $tleo = $this->createMock($tleoClassName);
+        $tleo->method('getTitle')->willReturn('MyTitle');
+        $tleo->method('getPid')->willReturn(new Pid('b0000001'));
+
+        if (method_exists($tleo, 'getAggregatedEpisodesCount')) {
+            $tleo->method('getAggregatedEpisodesCount')->willReturn($episodesCount);
+        }
+
+        if (method_exists($tleo, 'getAvailableClipsCount')) {
+            $tleo->method('getAvailableClipsCount')->willReturn($clipsCount);
+        }
+
+        if (method_exists($tleo, 'getAvailableGalleriesCount')) {
+            $tleo->method('getAvailableGalleriesCount')->willReturn($galleriesCount);
+        }
+
+        $context = $this->createMock(Episode::class);
+        $context->method('getTleo')->willReturn($tleo);
+
+        return $context;
+    }
+}


### PR DESCRIPTION
This deals with resolving branding placeholders:

`<!--BRANDING_PLACEHOLDER_TITLE-->` is replaced with the programem title
`<!--BRANDING_PLACEHOLDER_NAV-->` is replaced with a default navigation

`<!--BRANDING_PLACEHOLDER_SPONSOR-->` is currently replaced with an empty
string, as we do not yet have anything we need to pass into it.

Currently this only supports having Programmes as the context, this
shall need to deal with Groups once we have Group domain models.

See /programmes/b08y249y for an example of this in action.