### PR TITLE
Add additional prod_int and prod_test environments

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -6,6 +6,11 @@ imports:
 # http://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     locale: en
+    # These are the default feed environments for LIVE. They may be overridden
+    # on a per cosmos environment basis by editing config_prod_int.yml or
+    # config_prod_test.yml
+    app.feed_env.orbit: 'live'
+    app.feed_env.branding: 'live'
 
 framework:
     #esi: ~

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -25,11 +25,11 @@ monolog:
         app_access:
             type: stream
             channels: ['app_access']
-            path: '%kernel.logs_dir%/%kernel.environment%-access.log'
+            path: '%kernel.logs_dir%/prod-access.log'
             level: info
         nested:
             type: stream
-            path: '%kernel.logs_dir%/%kernel.environment%.log'
+            path: '%kernel.logs_dir%/prod.log'
             level: debug
         console:
             type: console

--- a/app/config/config_prod_int.yml
+++ b/app/config/config_prod_int.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: config_prod.yml }
+
+parameters:
+    app.feed_env.orbit: 'test'
+    app.feed_env.branding: 'live'

--- a/app/config/config_prod_test.yml
+++ b/app/config/config_prod_test.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: config_prod.yml }
+
+parameters:
+    app.feed_env.orbit: 'test'
+    app.feed_env.branding: 'test'

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -1,9 +1,7 @@
 parameters:
     app.default_locale: 'en_GB'
     app.orbit_client.class: BBC\BrandingClient\OrbitClient
-    app.orbit_client.env: 'test'
     app.branding_client.class: BBC\BrandingClient\BrandingClient
-    app.branding_client.env: 'test'
 
 services:
 
@@ -60,14 +58,14 @@ services:
         arguments:
             - '@csa_guzzle.client.default'
             - '@cache.app_page_chrome'
-            - { env: '%app.orbit_client.env%', mustache: { cache: '%kernel.cache_dir%/mustache' } }
+            - { env: '%app.feed_env.orbit%', mustache: { cache: '%kernel.cache_dir%/mustache' } }
 
     BBC\BrandingClient\BrandingClient:
         class: '%app.branding_client.class%'
         arguments:
             - '@csa_guzzle.client.default'
             - '@cache.app_page_chrome'
-            - { env: '%app.branding_client.env%' }
+            - { env: '%app.feed_env.branding%' }
 
     ### Translations
 

--- a/app/console
+++ b/app/console
@@ -17,7 +17,7 @@ $loader = require __DIR__.'/../vendor/autoload.php';
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev');
-$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(['--no-debug', '']) && $env !== 'prod';
+$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(['--no-debug', '']) && $env !== 'prod' && substr($env, 0, 5) !== 'prod-';
 
 if ($debug) {
     Debug::enable();

--- a/bake-scripts/01-configure-component
+++ b/bake-scripts/01-configure-component
@@ -41,7 +41,7 @@ def substitute_data(data):
     }
 
 
-def rewrite_application_parameters():
+def rewrite_application_parameters(config):
     appParamWriteFile = appRoot + "/app/config/parameters.yml"
     appParamReadFile = appRoot + "/app/config/parameters_prod.yml.dist"
 
@@ -50,11 +50,25 @@ def rewrite_application_parameters():
         raise IOError("MISSING FILE: " + appParamReadFile)
 
     src = Template(open(appParamReadFile).read())
-    parameters = src.substitute(substitute_data(component_config()))
+    parameters = src.substitute(substitute_data(config))
 
     print "Overwriting " + appParamWriteFile
     with open(appParamWriteFile, 'wt') as config_file:
         config_file.write(parameters)
+
+
+def rewrite_application_front_controller(symfony_env):
+    appFrontControllerFile = appRoot + "/web/app.php"
+
+    content = open(appFrontControllerFile).read()
+    content = content.replace(
+        "new AppKernel('prod', false)",
+        "new AppKernel('" + symfony_env + "', false)"
+    )
+
+    print "Overwriting " + appFrontControllerFile
+    with open(appFrontControllerFile, 'wt') as front_controller_file:
+        front_controller_file.write(content)
 
 
 def system_tweaks():
@@ -74,7 +88,7 @@ def system_tweaks():
         f.write("nginx hard nofile 6000\n")
 
 
-def regenerate_cache():
+def regenerate_cache(symfony_env):
     appTmpDir = appRoot + "/tmp"
     appConsoleFile = appRoot + "/app/console"
 
@@ -86,8 +100,8 @@ def regenerate_cache():
     # The warmup in cache:clear doesn't quite do what you expect so we should
     # call cache:warmup explicitly
     # http://symfony.com/blog/new-in-symfony-3-3-deprecated-cache-clear-with-warmup
-    subprocess.call(['php', appConsoleFile, '--env=prod', 'cache:clear', '--no-warmup', '--no-debug'])
-    subprocess.call(['php', appConsoleFile, '--env=prod', 'cache:warmup', '--no-debug'])
+    subprocess.call(['php', appConsoleFile, '--env=' + symfony_env, 'cache:clear', '--no-warmup', '--no-debug'])
+    subprocess.call(['php', appConsoleFile, '--env=' + symfony_env, 'cache:warmup', '--no-debug'])
 
     # Give the temp directory back to nginx
     subprocess.call(['chown', '-R', 'nginx:nginx', appTmpDir])
@@ -100,8 +114,15 @@ def create_monitoring_cronjob():
 
 def main():
     print "Setting up configurations..."
-    rewrite_application_parameters()
-    regenerate_cache()
+    config = component_config()
+
+    symfony_env = "prod"
+    if (config["environment"] != 'live'):
+        symfony_env = symfony_env + '_' + config["environment"]
+
+    rewrite_application_parameters(config)
+    rewrite_application_front_controller(symfony_env)
+    regenerate_cache(symfony_env)
     #create_monitoring_cronjob()
     system_tweaks()
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,36 @@
+Environments
+============
+
+The Frontend application is a standard Symfony application, which by default
+exposes three environments - `dev`, `test` and `prod`. This is however not quite
+sufficient for us as the frontend application may deployed to one of three
+Cosmos environments: INT, TEST or LIVE. Most of the time we want to keep the
+same configuration between these production environments. However there are some
+cases where we want to change configuration between the INT, TEST and LIVE
+Cosmos environments. Thus in total we have five environments.
+
+We have chosen to follow Symfony's existing convention for naming environments,
+but add extra environments based for the Cosmos environments we wish to
+customise away from the LIVE production environment. Our environments are as
+follows:
+
+* `dev`: for local development
+* `test`: for running unit tests
+* `prod`: for running the deployed app in the Cosmos LIVE environment
+* `prod_int`: for running the deployed app in the Cosmos INT environment
+* `prod_test`: for running the deployed app in the Cosmos TEST environment
+
+Both `prod_int` and `prod_test` inherit from `prod`. Only configuration
+parameters should need to be changed between these environments.
+
+
+## API crosstalk
+
+The primary reason for requiring different configuration between the INT, TEST
+and LIVE deployed environments is that any APIs that use certificates for
+authentication are subject to the BBC's "no-crosstalk" rule which states that
+INT and TEST applications can not request data from LIVE applications (but an
+application on INT can request data from TEST APIs). Thus INT and TEST may need
+to talk to TEST APIs as the LIVE API is inaccessible.
+
+


### PR DESCRIPTION
These environments shall be used on INT and TEST cosmos respectively.
LIVE cosmos shall use the `prod` environment.

Update the bake script to setup these environments. The cache warmup uses the right env, and the environment value in the front controller is overwritten.

Let's talk about naming for this lot tomorrow as it's rather contentious.