### PR TITLE
Add ContextEntityByPidValueResolver

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -29,11 +29,15 @@ services:
         arguments:
             $debug: '%kernel.debug%'
 
-    # This needs to be triggered before the any existing default Resolvers,
-    # the largest of which has a priority of 100
+    ### Argument Value Resolvers
+
+    App\ArgumentResolver\ContextEntityByPidValueResolver:
+        tags: [{name: 'controller.argument_value_resolver', priority: 0 }]
+
+    # This needs to be triggered before the RequestAttributeValueResolver,
+    # which has a priority of 100
     App\ArgumentResolver\IdentifierValueResolver:
         tags: [{name: 'controller.argument_value_resolver', priority: 125 }]
-
 
     ### Caches
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "bbc-rmp/translate": "^1.8",
         "bbc/branding-client": "^2.0.4",
         "bbc/gel-iconography-assets": "^1.2",
-        "bbc/programmes-pages-service": "^2.4.4",
+        "bbc/programmes-pages-service": "dev-master@dev",
         "cakephp/chronos": "^1.1",
         "csa/guzzle-bundle": "dev-master@dev",
         "doctrine/doctrine-bundle": "^1.6.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "96c48844d5986f00d62b8ae8892c8157",
+    "content-hash": "1d727278aec2c79e799d3ac6b0ebaaab",
     "packages": [
         {
             "name": "bbc-rmp/translate",
@@ -212,16 +212,16 @@
         },
         {
             "name": "bbc/programmes-pages-service",
-            "version": "v2.4.4",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bbc/programmes-pages-service.git",
-                "reference": "9d7d01b4d0f87a47b13af9c5296953b016767036"
+                "reference": "f1a9e33421078a425613538faac01ec0127c0737"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bbc/programmes-pages-service/zipball/9d7d01b4d0f87a47b13af9c5296953b016767036",
-                "reference": "9d7d01b4d0f87a47b13af9c5296953b016767036",
+                "url": "https://api.github.com/repos/bbc/programmes-pages-service/zipball/f1a9e33421078a425613538faac01ec0127c0737",
+                "reference": "f1a9e33421078a425613538faac01ec0127c0737",
                 "shasum": ""
             },
             "require": {
@@ -259,10 +259,10 @@
             ],
             "description": "A library for building /programmes pages",
             "support": {
-                "source": "https://github.com/bbc/programmes-pages-service/tree/v.2.4.4",
+                "source": "https://github.com/bbc/programmes-pages-service/tree/master",
                 "issues": "https://github.com/bbc/programmes-pages-service/issues"
             },
-            "time": "2017-07-26T15:31:35+00:00"
+            "time": "2017-07-27 14:19:08"
         },
         {
             "name": "behat/transliterator",
@@ -4559,6 +4559,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "bbc/programmes-pages-service": 20,
         "csa/guzzle-bundle": 20
     },
     "prefer-stable": false,

--- a/src/ArgumentResolver/ContextEntityByPidValueResolver.php
+++ b/src/ArgumentResolver/ContextEntityByPidValueResolver.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\ArgumentResolver;
+
+use BBC\ProgrammesPagesService\Domain\Entity\Brand;
+use BBC\ProgrammesPagesService\Domain\Entity\Episode;
+use BBC\ProgrammesPagesService\Domain\Entity\Clip;
+use BBC\ProgrammesPagesService\Domain\Entity\Collection;
+use BBC\ProgrammesPagesService\Domain\Entity\CoreEntity;
+use BBC\ProgrammesPagesService\Domain\Entity\Franchise;
+use BBC\ProgrammesPagesService\Domain\Entity\Gallery;
+use BBC\ProgrammesPagesService\Domain\Entity\Programme;
+use BBC\ProgrammesPagesService\Domain\Entity\ProgrammeContainer;
+use BBC\ProgrammesPagesService\Domain\Entity\ProgrammeItem;
+use BBC\ProgrammesPagesService\Domain\Entity\Group;
+use BBC\ProgrammesPagesService\Domain\Entity\Season;
+use BBC\ProgrammesPagesService\Domain\Entity\Series;
+use BBC\ProgrammesPagesService\Domain\Entity\Service;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Service\ServiceFactory;
+use Generator;
+use ReflectionClass;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * If a controller has an argument that is a Programme, Group or Service (or
+ * one of their subclasses) and the route has an argument called 'pid' then
+ * attempt to look up that pid and inject the returned entity into the
+ * controller.
+ *
+ * This shall throw a 404 if an entity of the given type and PID does not exist.
+ */
+class ContextEntityByPidValueResolver implements ArgumentValueResolverInterface
+{
+    // Explicitly define all subtypes of CoreEntity here, to avoid having to
+    // run an is_a() check which would be more expensive than an in_array()
+    private const SUPPORTED_CLASSES = [
+        // CoreEntity & child classes
+        CoreEntity::class,
+        Programme::class,
+        ProgrammeContainer::class,
+        ProgrammeItem::class,
+        Brand::class,
+        Series::class,
+        Episode::class,
+        Clip::class,
+        Group::class,
+        Collection::class,
+        Gallery::class,
+        Franchise::class,
+        Season::class,
+        // Service
+        Service::class,
+    ];
+
+    private $serviceFactory;
+
+    public function __construct(ServiceFactory $serviceFactory)
+    {
+        $this->serviceFactory = $serviceFactory;
+    }
+
+    public function supports(Request $request, ArgumentMetadata $argument): bool
+    {
+        return ($request->attributes->has('pid') && in_array($argument->getType(), self::SUPPORTED_CLASSES) && !$argument->isVariadic());
+    }
+
+    public function resolve(Request $request, ArgumentMetadata $argument): Generator
+    {
+        $type = $argument->getType();
+        $pid = new Pid($request->attributes->get('pid'));
+        $entity = null;
+
+        if (is_a($type, CoreEntity::class, true)) {
+            // Attempt to look up the CoreEntity. Filter to only return the
+            // type of entity requested
+
+            // Conveniently the filter to pass into findByPidFull is the short
+            // class name of the entity i.e. without the namespace
+            $entity = $this->serviceFactory->getCoreEntitiesService()->findByPidFull(
+                $pid,
+                (new ReflectionClass($type))->getShortName()
+            );
+        } elseif (is_a($type, Service::class, true)) {
+            // Attempt to look up the Service
+            $entity = $this->serviceFactory->getServicesService()->findByPidFull($pid);
+        }
+
+        if (!$entity) {
+            throw new NotFoundHttpException(sprintf(
+                'The item of type "%s" with PID "%s" was not found',
+                $type,
+                $pid
+            ));
+        }
+
+        yield $entity;
+    }
+}

--- a/src/Controller/SchedulesByDayController.php
+++ b/src/Controller/SchedulesByDayController.php
@@ -18,18 +18,13 @@ use Cake\Chronos\Chronos;
 class SchedulesByDayController extends BaseController
 {
     public function __invoke(
-        Pid $pid,
+        Service $service,
         ?string $date,
         NetworksService $networksService,
         ServicesService $servicesService,
         BroadcastsService $broadcastService,
         CollapsedBroadcastsService $collapsedBroadcastsService
     ) {
-        $service = $servicesService->findByPidFull($pid);
-        if (!$service) {
-            throw $this->createNotFoundException('Service not found');
-        }
-
         $this->setContext($service);
 
         $dateTimeToShow = $this->dateTimeToShow($date, $service);

--- a/src/Controller/SchedulesByMonthController.php
+++ b/src/Controller/SchedulesByMonthController.php
@@ -6,18 +6,12 @@ namespace App\Controller;
 use BBC\ProgrammesPagesService\Domain\ApplicationTime;
 use BBC\ProgrammesPagesService\Domain\Entity\Service;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
-use BBC\ProgrammesPagesService\Service\ServicesService;
 use Cake\Chronos\Date;
 
 class SchedulesByMonthController extends BaseController
 {
-    public function __invoke(Pid $pid, string $date, ServicesService $servicesService)
+    public function __invoke(Service $service, string $date)
     {
-        $service = $servicesService->findByPidFull($pid);
-        if (!$service) {
-            throw $this->createNotFoundException('Service not found');
-        }
-
         $this->setContext($service);
 
         $firstOfMonth = Date::createFromFormat('Y-m', $date, ApplicationTime::getLocalTimeZone())->firstOfMonth();

--- a/src/Controller/SchedulesByYearController.php
+++ b/src/Controller/SchedulesByYearController.php
@@ -6,18 +6,12 @@ namespace App\Controller;
 use BBC\ProgrammesPagesService\Domain\ApplicationTime;
 use BBC\ProgrammesPagesService\Domain\Entity\Service;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
-use BBC\ProgrammesPagesService\Service\ServicesService;
 use Cake\Chronos\Date;
 
 class SchedulesByYearController extends BaseController
 {
-    public function __invoke(Pid $pid, string $year, ServicesService $servicesService)
+    public function __invoke(Service $service, string $year)
     {
-        $service = $servicesService->findByPidFull($pid);
-        if (!$service) {
-            throw $this->createNotFoundException('Service not found');
-        }
-
         $this->setContext($service);
 
         $startOfYear = Date::createFromFormat('Y', $year, ApplicationTime::getLocalTimeZone())->firstOfYear();

--- a/tests/ArgumentResolver/ContextEntityByPidValueResolverTest.php
+++ b/tests/ArgumentResolver/ContextEntityByPidValueResolverTest.php
@@ -1,0 +1,124 @@
+<?php
+declare(strict_types = 1);
+namespace Tests\App\ArgumentResolver;
+
+use App\ArgumentResolver\ContextEntityByPidValueResolver;
+use BBC\ProgrammesPagesService\Domain\Entity\Programme;
+use BBC\ProgrammesPagesService\Domain\Entity\Group;
+use BBC\ProgrammesPagesService\Domain\Entity\Service;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use BBC\ProgrammesPagesService\Service\ServiceFactory;
+use BBC\ProgrammesPagesService\Service\CoreEntitiesService;
+use BBC\ProgrammesPagesService\Service\ServicesService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class ContextEntityByPidValueResolverTest extends TestCase
+{
+    /** @var ArgumentResolver */
+    private $resolver;
+
+    /** @var CoreEntitiesService */
+    private $coreEntitiesService;
+
+    /** @var ServicesService */
+    private $servicesService;
+
+    public function setUp()
+    {
+        $this->coreEntitiesService = $this->createMock(CoreEntitiesService::class);
+        $this->servicesService = $this->createMock(ServicesService::class);
+
+        $serviceFactory = $this->createMock(ServiceFactory::class);
+        $serviceFactory->method('getCoreEntitiesService')->willReturn($this->coreEntitiesService);
+        $serviceFactory->method('getServicesService')->willReturn($this->servicesService);
+
+        $this->resolver = new ArgumentResolver(null, [
+            new ContextEntityByPidValueResolver($serviceFactory),
+        ]);
+    }
+
+    public function testResolveProgramme()
+    {
+        $request = Request::create('/');
+        $request->attributes->set('pid', 'b0000001');
+        $controller = function (Programme $pid) {
+        };
+
+        $programme = $this->createMock(Programme::class);
+
+        $this->coreEntitiesService->expects($this->once())->method('findByPidFull')
+            ->with(new Pid('b0000001'), 'Programme')
+            ->willReturn($programme);
+
+        $this->servicesService->expects($this->never())->method('findByPidFull');
+
+        $this->assertEquals(
+            [$programme],
+            $this->resolver->getArguments($request, $controller)
+        );
+    }
+
+    public function testResolveGroup()
+    {
+        $request = Request::create('/');
+        $request->attributes->set('pid', 'b0000001');
+        $controller = function (Group $pid) {
+        };
+
+        $group = $this->createMock(Group::class);
+
+        $this->coreEntitiesService->expects($this->once())->method('findByPidFull')
+            ->with(new Pid('b0000001'), 'Group')
+            ->willReturn($group);
+
+        $this->servicesService->expects($this->never())->method('findByPidFull');
+
+        $this->assertEquals(
+            [$group],
+            $this->resolver->getArguments($request, $controller)
+        );
+    }
+
+    public function testResolveService()
+    {
+        $request = Request::create('/');
+        $request->attributes->set('pid', 'b0000001');
+        $controller = function (Service $pid) {
+        };
+
+        $service = $this->createMock(Service::class);
+
+        $this->coreEntitiesService->expects($this->never())->method('findByPidFull');
+
+        $this->servicesService->expects($this->once())->method('findByPidFull')
+            ->with(new Pid('b0000001'))
+            ->willReturn($service);
+
+        $this->assertEquals(
+            [$service],
+            $this->resolver->getArguments($request, $controller)
+        );
+    }
+
+    public function testResolveOfUnfoundEntityThrows404()
+    {
+        $request = Request::create('/');
+        $request->attributes->set('pid', 'b0000001');
+        $controller = function (Programme $pid) {
+        };
+
+        $this->coreEntitiesService->expects($this->once())->method('findByPidFull')
+            ->with(new Pid('b0000001'), 'Programme')
+            ->willReturn(null);
+
+        $this->servicesService->expects($this->never())->method('findByPidFull');
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('The item of type "' . Programme::class . '" with PID "b0000001" was not found');
+
+        $this->resolver->getArguments($request, $controller);
+    }
+}


### PR DESCRIPTION
This automatically looks up an entity based upon the pid value of the
route and the typehinting on the Controller, to save you having to
request the item through the service in every controller and then throw
a 404 if the entity does not exist.

The typehinting thing is particularly powerful as you can request an
instance of ProgrammeContainer in your controller and this will throw a
404 if the pid exists but is an Episode. This is useful for Pages like
/programmes/:pid/series that is only valid for Brands and Series.