### PR TITLE
Redirect to programme options location if required

### DIFF
--- a/src/ArgumentResolver/ContextEntityByPidValueResolver.php
+++ b/src/ArgumentResolver/ContextEntityByPidValueResolver.php
@@ -2,6 +2,7 @@
 declare(strict_types = 1);
 namespace App\ArgumentResolver;
 
+use App\Exception\ProgrammeOptionsRedirectHttpException;
 use BBC\ProgrammesPagesService\Domain\Entity\Brand;
 use BBC\ProgrammesPagesService\Domain\Entity\Episode;
 use BBC\ProgrammesPagesService\Domain\Entity\Clip;
@@ -84,6 +85,14 @@ class ContextEntityByPidValueResolver implements ArgumentValueResolverInterface
                 $pid,
                 (new ReflectionClass($type))->getShortName()
             );
+
+            // Redirect if the options demand it
+            if ($entity && $entity->getOptions()->getOption('pid_override_url') && $entity->getOptions()->getOption('pid_override_code')) {
+                throw new ProgrammeOptionsRedirectHttpException(
+                    $entity->getOptions()->getOption('pid_override_url'),
+                    $entity->getOptions()->getOption('pid_override_code')
+                );
+            }
         } elseif (is_a($type, Service::class, true)) {
             // Attempt to look up the Service
             $entity = $this->serviceFactory->getServicesService()->findByPidFull($pid);

--- a/src/EventSubscriber/FindByPidRouterSubscriber.php
+++ b/src/EventSubscriber/FindByPidRouterSubscriber.php
@@ -2,6 +2,7 @@
 declare(strict_types = 1);
 namespace App\EventSubscriber;
 
+use App\Exception\ProgrammeOptionsRedirectHttpException;
 use BBC\ProgrammesPagesService\Domain\Entity\Clip;
 use BBC\ProgrammesPagesService\Domain\Entity\Collection;
 use BBC\ProgrammesPagesService\Domain\Entity\Episode;
@@ -74,6 +75,14 @@ class FindByPidRouterSubscriber implements EventSubscriberInterface
         // Attempt to find a Programme or Group
         $coreEntity = $this->serviceFactory->getCoreEntitiesService()->findByPidFull($pid);
         if ($coreEntity) {
+            // Redirect if the options demand it
+            if ($coreEntity && $coreEntity->getOptions()->getOption('pid_override_url') && $coreEntity->getOptions()->getOption('pid_override_code')) {
+                throw new ProgrammeOptionsRedirectHttpException(
+                    $coreEntity->getOptions()->getOption('pid_override_url'),
+                    $coreEntity->getOptions()->getOption('pid_override_code')
+                );
+            }
+
             if ($coreEntity instanceof ProgrammeContainer) {
                 if (!$coreEntity->getParent()) {
                     $request->attributes->set('programme', $coreEntity);

--- a/src/Exception/ProgrammeOptionsRedirectHttpException.php
+++ b/src/Exception/ProgrammeOptionsRedirectHttpException.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types = 1);
+namespace App\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * Symfony provides several exceptions that result in the Framework emiting a
+ * response, but it doesn't provide one for 301/302 redirects.
+ *
+ * This Exception takes a location and status code, and shall send a redirect
+ * request to that location. This being an exception allows us to trigger the
+ * redirect in places that are usually not able to return a response.
+ */
+class ProgrammeOptionsRedirectHttpException extends HttpException
+{
+    public function __construct(string $location, int $status = 301, \Exception $previous = null, $code = 0)
+    {
+        parent::__construct(
+            $status,
+            sprintf('Programme Options has triggered a "%s" redirect to "%s"', $status, $location),
+            $previous,
+            ['location' => $location, 'cache-control' => 'public, max-age=3600'],
+            $code
+        );
+    }
+}

--- a/tests/ArgumentResolver/ContextEntityByPidValueResolverTest.php
+++ b/tests/ArgumentResolver/ContextEntityByPidValueResolverTest.php
@@ -3,8 +3,10 @@ declare(strict_types = 1);
 namespace Tests\App\ArgumentResolver;
 
 use App\ArgumentResolver\ContextEntityByPidValueResolver;
+use App\Exception\ProgrammeOptionsRedirectHttpException;
 use BBC\ProgrammesPagesService\Domain\Entity\Programme;
 use BBC\ProgrammesPagesService\Domain\Entity\Group;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
 use BBC\ProgrammesPagesService\Domain\Entity\Service;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 use BBC\ProgrammesPagesService\Service\ServiceFactory;
@@ -118,6 +120,31 @@ class ContextEntityByPidValueResolverTest extends TestCase
 
         $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('The item of type "' . Programme::class . '" with PID "b0000001" was not found');
+
+        $this->resolver->getArguments($request, $controller);
+    }
+
+    public function testResolveOfEnityWithRedirectsThrowsARedirect()
+    {
+        $programme = $this->createMock(Programme::class);
+        $programme->method('getOptions')->willReturn(new Options([
+            'pid_override_url' => 'http://example.com',
+            'pid_override_code' => 301,
+        ]));
+
+        $request = Request::create('/');
+        $request->attributes->set('pid', 'b0000001');
+        $controller = function (Programme $pid) {
+        };
+
+        $this->coreEntitiesService->expects($this->once())->method('findByPidFull')
+            ->with(new Pid('b0000001'), 'Programme')
+            ->willReturn($programme);
+
+        $this->servicesService->expects($this->never())->method('findByPidFull');
+
+        $this->expectException(ProgrammeOptionsRedirectHttpException::class);
+        $this->expectExceptionMessage('Programme Options has triggered a "301" redirect to "http://example.com"');
 
         $this->resolver->getArguments($request, $controller);
     }

--- a/tests/Exception/ProgrammeOptionsRedirectHttpExceptionTest.php
+++ b/tests/Exception/ProgrammeOptionsRedirectHttpExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types = 1);
+namespace Tests\App\Exception;
+
+use App\Exception\ProgrammeOptionsRedirectHttpException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class ProgrammeOptionsRedirectHttpExceptionTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $exception = new ProgrammeOptionsRedirectHttpException('http://example.com', 301);
+        $this->assertInstanceOf(HttpException::class, $exception);
+        $this->assertSame(301, $exception->getStatusCode());
+
+        $expectedHeaders = [
+            'location' => 'http://example.com',
+            'cache-control' => 'public, max-age=3600',
+        ];
+
+        $this->assertSame($expectedHeaders, $exception->getHeaders());
+        $this->assertSame(
+            'Programme Options has triggered a "301" redirect to "http://example.com"',
+            $exception->getMessage()
+        );
+    }
+}


### PR DESCRIPTION
Add ProgrammeOptionsRedirectHttpException that returns a redirect to the
given location.

Throw that exception when we get an entity in the
ContextEntityByPidValueResolver and FindByPidRouterSubscriber.

This is done in both places as if the FindByPidRouterSubscriber adds a
domain object to the request attributes then the
ContextEntityByPidValueResolver is not fired, because the
RequestAttributeValueResolver resolves the controller arguments first.