### PR TITLE
Branding / Orbit should store results in Redis

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -37,8 +37,6 @@ framework:
                 # the only aim of default_lifetime is to prevent setting permanent keys, please don't use the default_lifetime in the code.
                 # PSR-6 consider "0" or NULL value as a way to store the key for as long as the implementation allows.
                 default_lifetime: 120
-            cache.app_page_chrome:
-                adapter: cache.adapter.filesystem
 
 # Twig Configuration
 twig:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -65,15 +65,18 @@ services:
         class: '%app.orbit_client.class%'
         arguments:
             - '@csa_guzzle.client.default'
-            - '@cache.app_page_chrome'
-            - { env: '%app.feed_env.orbit%', mustache: { cache: '%kernel.cache_dir%/mustache' } }
+            - '@cache.programmes'
+            - env: '%app.feed_env.orbit%'
+              cacheKeyPrefix: 'frontend.%cosmos_component_release%.orbit'
+              mustache: { cache: '%kernel.cache_dir%/mustache' }
 
     BBC\BrandingClient\BrandingClient:
         class: '%app.branding_client.class%'
         arguments:
             - '@csa_guzzle.client.default'
-            - '@cache.app_page_chrome'
-            - { env: '%app.feed_env.branding%' }
+            - '@cache.programmes'
+            - env: '%app.feed_env.branding%'
+              cacheKeyPrefix: 'frontend.%cosmos_component_release%.branding'
 
     ### Translations
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-redis": "*",
         "bbc-rmp/cloudwatch-monitoringhandler": "^1.0",
         "bbc-rmp/translate": "^1.8",
-        "bbc/branding-client": "^2.0.4",
+        "bbc/branding-client": "^2.1.0",
         "bbc/gel-iconography-assets": "^1.2",
         "bbc/programmes-pages-service": "dev-master@dev",
         "cakephp/chronos": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d727278aec2c79e799d3ac6b0ebaaab",
+    "content-hash": "d875184e47eefc6204e82b1d557f613e",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -182,16 +182,16 @@
         },
         {
             "name": "bbc/branding-client",
-            "version": "v2.0.4",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bbc/branding-client.git",
-                "reference": "34402ee3a7a79d1348071b6d352a904a5fd7a947"
+                "reference": "4c805625816b041a917266f03736aa7eb068155f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bbc/branding-client/zipball/34402ee3a7a79d1348071b6d352a904a5fd7a947",
-                "reference": "34402ee3a7a79d1348071b6d352a904a5fd7a947",
+                "url": "https://api.github.com/repos/bbc/branding-client/zipball/4c805625816b041a917266f03736aa7eb068155f",
+                "reference": "4c805625816b041a917266f03736aa7eb068155f",
                 "shasum": ""
             },
             "require": {
@@ -221,10 +221,10 @@
             ],
             "description": "PHP Branding client",
             "support": {
-                "source": "https://github.com/bbc/branding-client/tree/v2.0.4",
+                "source": "https://github.com/bbc/branding-client/tree/v2.1.0",
                 "issues": "https://github.com/bbc/branding-client/issues"
             },
-            "time": "2017-07-18T16:24:12+00:00"
+            "time": "2017-07-31T16:11:25+00:00"
         },
         {
             "name": "bbc/doctrine-extensions",


### PR DESCRIPTION
Previously they were using a local filesystem cache.
Use the same cache pool as service queries.