### PR TITLE
Cache the creation of IntlDateFormatter in the TranslateableTrait

### DIFF
--- a/src/Translate/TranslatableTrait.php
+++ b/src/Translate/TranslatableTrait.php
@@ -12,6 +12,9 @@ trait TranslatableTrait
     /** @var TranslateProvider */
     protected $translateProvider;
 
+    /** @var array */
+    private $dateFormatterCache = [];
+
     /**
      * Formatter for international dates in a "Text" format. Need something with translated words in it?
      * You want this one
@@ -29,16 +32,28 @@ trait TranslatableTrait
             $timeZone = ApplicationTime::getLocalTimeZone();
         }
         $locale = $this->translateProvider->getTranslate()->getLocale();
-        $formatter = IntlDateFormatter::create(
-            $locale,
-            IntlDateFormatter::LONG,
-            IntlDateFormatter::NONE,
-            $timeZone,
-            IntlDateFormatter::GREGORIAN,
-            $format
-        );
 
-        $output = $formatter->format($dateTime->getTimestamp());
+        // Creating new instances of IntlDateFormatter is expensive.
+        // Changing the timezone of an existing instance is less expensive but
+        // still has some overhead.
+        // Changing the pattern of an existing instance is pretty much free
+        // compared to creating a new instance / toggling the timezone.
+        // When we render a page we should only ever have one language, and one
+        // timezone so create a cached instance of an IntlDateFormatter that is
+        // configured with a give language and timezone.
+        $cacheKey = $locale . ':' . $timeZone->getName();
+        if (!isset($this->dateFormatterCache[$cacheKey])) {
+            $this->dateFormatterCache[$cacheKey] = IntlDateFormatter::create(
+                $locale,
+                IntlDateFormatter::LONG,
+                IntlDateFormatter::NONE,
+                $timeZone,
+                IntlDateFormatter::GREGORIAN
+            );
+        }
+
+        $this->dateFormatterCache[$cacheKey]->setPattern($format);
+        $output = $this->dateFormatterCache[$cacheKey]->format($dateTime->getTimestamp());
         //@TODO figure out if we need RMP\Translate's DateCorrection or if our OS now correctly handles these spellings
         /*
         $dateCorrection = new DateCorrection();


### PR DESCRIPTION
Creating IntlDateFormatters are expensive and we don't need a whole new
one every time, instead we can just update the format.

This should save about 8ms on a schedule page.