### PR TITLE
Make BasePresenter->getUniqueId() public

### DIFF
--- a/src/DsShared/BasePresenter.php
+++ b/src/DsShared/BasePresenter.php
@@ -70,17 +70,10 @@ abstract class BasePresenter
     }
 
     /**
-     * The name of the design system
-     *
-     * @return string
-     */
-    abstract protected function getDesignSystem(): string;
-
-    /**
      * Get or generate a unique ID. Once generated once the same one will be used
      * Only used for unique references in a single render
      */
-    protected function getUniqueID(): string
+    public function getUniqueId(): string
     {
         if (!$this->uniqueId) {
             $parts = explode('\\', static::class);
@@ -90,6 +83,13 @@ abstract class BasePresenter
 
         return $this->uniqueId;
     }
+
+    /**
+     * The name of the design system
+     *
+     * @return string
+     */
+    abstract protected function getDesignSystem(): string;
 
     /**
      * Validate options. Should be overridden.

--- a/tests/Ds2013/PresenterTest.php
+++ b/tests/Ds2013/PresenterTest.php
@@ -45,43 +45,19 @@ class PresenterTest extends TestCase
         $presenter->getOption('garbage');
     }
 
-    public function testGetUniqueID()
+    public function testGetUniqueId()
     {
         $presenter = $this->getMockForAbstractClass(Presenter::class, [], 'TestDemoObjectPresenter');
-        $uniqueIdFn = $this->boundCall('getUniqueId', $presenter);
-
-        $initialId = $uniqueIdFn();
+        $initialId = $presenter->getUniqueId();
 
         // Assert format
         $this->assertRegExp('/^ds-2013-TestDemoObjectPresenter-[0-9]+$/', $initialId);
 
         // Assert we get the same value if we call uniqueID multiple times on the same Presenter
-        $this->assertSame($initialId, $uniqueIdFn());
+        $this->assertSame($initialId, $presenter->getUniqueId());
 
         // Assert a new presenter gets a different ID
         $secondPresenter = $this->getMockForAbstractClass(Presenter::class, [], 'TestDemoObjectPresenter');
-        $secondPresenterUniqueIdFn = $this->boundCall('getUniqueId', $secondPresenter);
-
-        $this->assertNotEquals($initialId, $secondPresenterUniqueIdFn());
-    }
-
-    /**
-     * This is funky. It generates a closure that has its scope bound to a
-     * presenter, which means it has access to call protected function names.
-     * Thus we can call boundCall('protectedFn') to create a function that
-     * calls $protectedFunction->protectedFn().
-     */
-    private function boundCall(string $protectedFunctionName, ?Presenter $presenter = null): callable
-    {
-        if (!$presenter) {
-            $presenter = $this->getMockForAbstractClass(Presenter::class);
-        }
-
-        // Define a closure that will call the protected method using "this".
-        $callable = function (...$args) use ($protectedFunctionName) {
-            return $this->{$protectedFunctionName}(...$args);
-        };
-        // Bind the closure to $presenter's scope.
-        return $callable->bindTo($presenter, $presenter);
+        $this->assertNotEquals($initialId, $secondPresenter->getUniqueId());
     }
 }

--- a/tests/DsAmen/PresenterTest.php
+++ b/tests/DsAmen/PresenterTest.php
@@ -46,43 +46,19 @@ class PresenterTest extends TestCase
         $presenter->getOption('garbage');
     }
 
-    public function testGetUniqueID()
+    public function testGetUniqueId()
     {
         $presenter = $this->getMockForAbstractClass(Presenter::class, [], 'TestAmenObjectPresenter');
-        $uniqueIdFn = $this->boundCall('getUniqueId', $presenter);
-
-        $initialId = $uniqueIdFn();
+        $initialId = $presenter->getUniqueId();
 
         // Assert format
         $this->assertRegExp('/^ds-amen-TestAmenObjectPresenter-[0-9]+$/', $initialId);
 
         // Assert we get the same value if we call uniqueID multiple times on the same Presenter
-        $this->assertSame($initialId, $uniqueIdFn());
+        $this->assertSame($initialId, $presenter->getUniqueId());
 
         // Assert a new presenter gets a different ID
         $secondPresenter = $this->getMockForAbstractClass(Presenter::class, [], 'TestAmenObjectPresenter');
-        $secondPresenterUniqueIdFn = $this->boundCall('getUniqueId', $secondPresenter);
-
-        $this->assertNotEquals($initialId, $secondPresenterUniqueIdFn());
-    }
-
-    /**
-     * This is funky. It generates a closure that has its scope bound to a
-     * presenter, which means it has access to call protected function names.
-     * Thus we can call boundCall('protectedFn') to create a function that
-     * calls $protectedFunction->protectedFn().
-     */
-    private function boundCall(string $protectedFunctionName, ?Presenter $presenter = null): callable
-    {
-        if (!$presenter) {
-            $presenter = $this->getMockForAbstractClass(Presenter::class);
-        }
-
-        // Define a closure that will call the protected method using "this".
-        $callable = function (...$args) use ($protectedFunctionName) {
-            return $this->{$protectedFunctionName}(...$args);
-        };
-        // Bind the closure to $presenter's scope.
-        return $callable->bindTo($presenter, $presenter);
+        $this->assertNotEquals($initialId, $secondPresenter->getUniqueId());
     }
 }

--- a/tests/DsShared/PresenterTest.php
+++ b/tests/DsShared/PresenterTest.php
@@ -46,43 +46,19 @@ class PresenterTest extends TestCase
         $presenter->getOption('garbage');
     }
 
-    public function testGetUniqueID()
+    public function testGetUniqueId()
     {
         $presenter = $this->getMockForAbstractClass(Presenter::class, [], 'TestSharedObjectPresenter');
-        $uniqueIdFn = $this->boundCall('getUniqueId', $presenter);
-
-        $initialId = $uniqueIdFn();
+        $initialId = $presenter->getUniqueId();
 
         // Assert format
         $this->assertRegExp('/^ds-shared-TestSharedObjectPresenter-[0-9]+$/', $initialId);
 
         // Assert we get the same value if we call uniqueID multiple times on the same Presenter
-        $this->assertSame($initialId, $uniqueIdFn());
+        $this->assertSame($initialId, $presenter->getUniqueId());
 
         // Assert a new presenter gets a different ID
         $secondPresenter = $this->getMockForAbstractClass(Presenter::class, [], 'TestSharedObjectPresenter');
-        $secondPresenterUniqueIdFn = $this->boundCall('getUniqueId', $secondPresenter);
-
-        $this->assertNotEquals($initialId, $secondPresenterUniqueIdFn());
-    }
-
-    /**
-     * This is funky. It generates a closure that has its scope bound to a
-     * presenter, which means it has access to call protected function names.
-     * Thus we can call boundCall('protectedFn') to create a function that
-     * calls $protectedFunction->protectedFn().
-     */
-    private function boundCall(string $protectedFunctionName, ?Presenter $presenter = null): callable
-    {
-        if (!$presenter) {
-            $presenter = $this->getMockForAbstractClass(Presenter::class);
-        }
-
-        // Define a closure that will call the protected method using "this".
-        $callable = function (...$args) use ($protectedFunctionName) {
-            return $this->{$protectedFunctionName}(...$args);
-        };
-        // Bind the closure to $presenter's scope.
-        return $callable->bindTo($presenter, $presenter);
+        $this->assertNotEquals($initialId, $secondPresenter->getUniqueId());
     }
 }


### PR DESCRIPTION
We'll need to use this within templates so don't hide it away.
Has the side-effect of simplifying testing this function.