### PR TITLE
Cache 404s for 60 seconds

### DIFF
--- a/src/EventSubscriber/ResponseSubscriber.php
+++ b/src/EventSubscriber/ResponseSubscriber.php
@@ -27,8 +27,14 @@ class ResponseSubscriber implements EventSubscriberInterface
     {
         $response = $event->getResponse();
 
-        // Always add the following varys to whatever is currently there
-        // The Vary header indicate what makes a HTTP object Vary so they can be cached separately
+        // Don't run on subrequests, such as when handling exceptions
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        // Always add the following headers to vary on, so that differences in
+        // these headers are cached separately. Add these to any already
+        // existing value rather than overwriting.
         $response->setVary(['X-CDN', 'X-BBC-Edge-Scheme'], false);
 
         // X-UA-Compatible header choose what version of Internet Explorer the page should be rendered as.

--- a/tests/Controller/ExceptionControllerTest.php
+++ b/tests/Controller/ExceptionControllerTest.php
@@ -17,6 +17,8 @@ class ExceptionControllerTest extends BaseWebTestCase
         // The test page for all errors, always returns a 200 status
         $this->assertResponseStatusCode($client, 200);
 
+        $this->assertHasRequiredResponseHeaders($client, 'max-age=60, public');
+
         $this->assertEquals(
             'Sorry, that page was not found',
             $crawler->filter('.programmes-page h1')->text()
@@ -35,6 +37,8 @@ class ExceptionControllerTest extends BaseWebTestCase
 
         // The test page for all errors, always returns a 200 status
         $this->assertResponseStatusCode($client, 200);
+
+        $this->assertHasRequiredResponseHeaders($client, 'no-cache, private');
 
         $this->assertEquals(
             'Internal server error',


### PR DESCRIPTION
This avoids repeated requests to non-existant content always hitting the
PAL.

Also enure the ResponseSubscriber only runs on the master request to
avoid duplicating Vary headers when serving exceptions.

Fixes PROGRAMMES-5834