### PR TITLE
Only show two related links in promos on tlec page

### DIFF
--- a/app/Resources/views/find_by_pid/tlec.html.twig
+++ b/app/Resources/views/find_by_pid/tlec.html.twig
@@ -34,6 +34,7 @@
                         {% set promo_widths = loop.first and has_double_width_first_promo ? '2/3@gel3b 1/2@gel5' : '1/2@gel3 1/3@gel3b 1/4@gel5' %}
                         <li class="grid__item {{ promo_widths }}">
                             {{- ds_amen('promotion', promotion, {
+                                'related_links_count': 2,
                                 'media_variant': 'media--column media--card',
                                 'cta_class': 'br-box-secondary',
                                 'branding_name': 'secondary',

--- a/src/DsAmen/Organism/Promotion/PromotionPresenter.php
+++ b/src/DsAmen/Organism/Promotion/PromotionPresenter.php
@@ -32,7 +32,7 @@ class PromotionPresenter extends Presenter
         // display options
         'show_image' => true,
         'show_synopsis' => true,
-        'show_related_links' => true,
+        'related_links_count' => 999,
 
         // classes & elements
         'h_tag' => 'h4',
@@ -122,11 +122,7 @@ class PromotionPresenter extends Presenter
      */
     public function getRelatedLinks(): array
     {
-        if (!$this->options['show_related_links']) {
-            return [];
-        }
-
-        return $this->promotion->getRelatedLinks();
+        return array_slice($this->promotion->getRelatedLinks(), 0, $this->options['related_links_count']);
     }
 
     /**
@@ -175,8 +171,8 @@ class PromotionPresenter extends Presenter
             throw new InvalidOptionException('show_synopsis option must be a boolean');
         }
 
-        if (!is_bool($options['show_related_links'])) {
-            throw new InvalidOptionException('show_related_links option must be a boolean');
+        if (!is_int($options['related_links_count']) || $options['related_links_count'] < 0) {
+            throw new InvalidOptionException('related_links_count option must 0 or a positive integer');
         }
     }
 }

--- a/src/DsAmen/Organism/Promotion/promotion.html.twig
+++ b/src/DsAmen/Organism/Promotion/promotion.html.twig
@@ -9,7 +9,7 @@
             {%- if promotion.getOption('show_synopsis') -%}
                 <p class="gel-brevier media__meta-row">{{ promotion.getSynopsis() }}</p>
             {%- endif -%}
-            {% if promotion.getOption('show_related_links') and promotion.getRelatedLinks() %}
+            {% if promotion.getRelatedLinks() %}
                 <ul class="list-standard gel-brevier box-link__elevated">
                     {%- for link in promotion.getRelatedLinks() -%}
                         <li><a href="{{ link.getUri() }}" data-linktrack="{{ promotion.getOption('link_location_prefix') }}relatedlink">


### PR DESCRIPTION
PromotionPresenter option 'show_related_links' is replaced by
'related_links_count' which takes an integer.

See PROGRAMMES-5820