### PR TITLE
Use consistent naming for route variables

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -69,8 +69,9 @@ schedules_by_network_url_key:
     requirements: { networkUrlKey: '[a-zA-Z0-9]{2,35}' }
 
 schedules_on_now:
-    path: /schedules/network/{networkKey}/on-now
+    path: /schedules/network/{networkUrlKey}/on-now
     defaults: { _controller: App\Controller\SchedulesOnNowController }
+    requirements: { networkUrlKey: '[a-zA-Z0-9]{2,35}' }
 
 # Labs routes, for testing things
 

--- a/src/Controller/SchedulesOnNowController.php
+++ b/src/Controller/SchedulesOnNowController.php
@@ -19,12 +19,12 @@ class SchedulesOnNowController extends BaseController
         NetworksService $networksService,
         HelperFactory $helperFactory,
         Request $request,
-        string $networkKey
+        string $networkUrlKey
     ) {
-        $network = $networksService->findByUrlKeyWithDefaultService($networkKey);
+        $network = $networksService->findByUrlKeyWithDefaultService($networkUrlKey);
 
         if (!$network || !$network->getDefaultService()) {
-            throw $this->createNotFoundException('No network or service found from network key ' . $networkKey);
+            throw $this->createNotFoundException('No network or service found from network key ' . $networkUrlKey);
         }
 
         $this->setTimeZone($network);


### PR DESCRIPTION
We've got two routes next to each other that use slightly different
labels for the same thing. Might as well make them consistant.

/cc @mattgreenham @tatitati 