### PR TITLE
Move 3rd party routes into routing_3rd_party

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,3 +1,8 @@
+# This file shall contain routes used to build URLs that are defined within the
+# application. Routes that are not served by this application should be stored
+# in routing_3rd_party.yml. This includes routes that will eventually be served
+# by this application but have not yet been migrated
+
 status:
     path: /status
     defaults: { _controller: App\Controller\StatusController }
@@ -15,22 +20,6 @@ find_by_pid:
     # !find_by_pid is a special value, that shall be converted into an proper
     # _controller value (i.e. a class name) by the FindByPidRouterSubscriber
     defaults: { _controller: '!find_by_pid' }
-    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
-
-programme_clips:
-    path: /programmes/{pid}/clips
-    defaults: { _controller: App\Controller\ProgrammeClips }
-    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
-
-#TODO implement slice and filter properly
-programme_broadcasts:
-    path: /programmes/{pid}/broadcasts
-    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
-    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
-
-programme_episodes:
-    path: /programmes/{pid}/episodes
-    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
     requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
 
 schedules_home:

--- a/app/config/routing_3rd_party.yml
+++ b/app/config/routing_3rd_party.yml
@@ -3,7 +3,7 @@
 # fall into one of two buckets:
 #
 # 1) A url to an external product, e.g. iplayer, iplayer radio
-# 2) A url to a /programme page we have not yet migrated. As we migrate pages,
+# 2) A url to a /programmes page we have not yet migrated. As we migrate pages,
 #    we shall move these routes into the main routing.yml.
 #
 # All routes in this file shall be configured with
@@ -58,6 +58,13 @@ programme_clips:
 
 programme_galleries:
     path: /programmes/{pid}/galleries
+    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
+    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
+    schemes: [http]
+
+# TODO implement slice and filter parameters properly
+programme_broadcasts:
+    path: /programmes/{pid}/broadcasts
     defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
     requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
     schemes: [http]


### PR DESCRIPTION
The programme_episodes and programme_clips routes were already present
in the 3rd party file, only programme_broadcasts needed to be moved.
Add a comment at the top of the main routing file to point people to the
3rd party one.

/cc @felipeparaujo 