### PR TITLE
Enforce PHPSCS rule that avoids else/elseif after an early return

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,8 +25,6 @@
         <!-- We don't care about enforcing using sprintf in error messages -->
         <exclude name="Symfony.Errors.ExceptionMessage.Invalid"/>
 
-        <exclude name="Symfony.Formatting.ReturnOrThrow.Invalid"/>
-
         <!-- FUNCTIONS -->
         <!-- Ignore missing function docblocks as we hint parameter and return types using proper typehints -->
         <exclude name="Symfony.Commenting.FunctionComment.Missing"/>

--- a/src/Controller/SchedulesByDayController.php
+++ b/src/Controller/SchedulesByDayController.php
@@ -151,11 +151,13 @@ class SchedulesByDayController extends BaseController
     {
         if ($diffInDays == 0) {
             return 'today';
-        } elseif ($diffInDays < 0) {
-            return 'past';
-        } else {
-            return 'future';
         }
+
+        if ($diffInDays < 0) {
+            return 'past';
+        }
+
+        return 'future';
     }
 
     private function getScheduleCurrentFortnight(int $diffInDays): string

--- a/src/Controller/StatusController.php
+++ b/src/Controller/StatusController.php
@@ -102,10 +102,13 @@ class StatusController extends AbstractController
                 // way I can see to be specific to the case of "DB server went down"
                 // is to do a string compare on the error message.
                 return true;
-            } elseif ($e->getCode() == 2002) {
+            }
+
+            if ($e->getCode() == 2002) {
                 // Connection timeout
                 return true;
             }
+
             return false;
         } catch (DriverException $e) {
             if ($e->getErrorCode() == 1213 || $e->getErrorCode() == 1205) {
@@ -113,7 +116,9 @@ class StatusController extends AbstractController
                 // and exit with a zero exit status allowing the processor
                 // to restart
                 return true;
-            } elseif ($e->getErrorCode() == 2006) {
+            }
+
+            if ($e->getErrorCode() == 2006) {
                 // General error: 2006 MySQL server has gone away
                 return true;
             }

--- a/src/DsAmen/Molecule/Duration/DurationPresenter.php
+++ b/src/DsAmen/Molecule/Duration/DurationPresenter.php
@@ -61,7 +61,9 @@ class DurationPresenter extends Presenter
             return $this->getHours() . ":"
                 . sprintf('%02d', $this->getMinutes()) . ":"
                 . sprintf('%02d', $this->getSeconds());
-        } elseif ($this->getMinutes() > 0) {
+        }
+
+        if ($this->getMinutes() > 0) {
             // 1+ minutes e.g. (1:23)
             return $this->getMinutes() . ":"
                 . sprintf('%02d', $this->getSeconds());

--- a/src/DsShared/Helpers/PlayTranslationsHelper.php
+++ b/src/DsShared/Helpers/PlayTranslationsHelper.php
@@ -164,17 +164,28 @@ class PlayTranslationsHelper
     {
         if ($programmeItem->isAudio()) {
             return 'listen';
-        } elseif ($programmeItem->isVideo()) {
-            return 'watch';
-        } elseif ($programmeItem->isRadio()) {
-            return 'listen';
-        } elseif ($programmeItem->isTv()) {
-            return 'watch';
-        } elseif ($service && $service->isRadio()) {
-            return 'listen';
-        } elseif ($service && $service->isTv()) {
+        }
+
+        if ($programmeItem->isVideo()) {
             return 'watch';
         }
+
+        if ($programmeItem->isRadio()) {
+            return 'listen';
+        }
+
+        if ($programmeItem->isTv()) {
+            return 'watch';
+        }
+
+        if ($service && $service->isRadio()) {
+            return 'listen';
+        }
+
+        if ($service && $service->isTv()) {
+            return 'watch';
+        }
+
         return 'play';
     }
 }

--- a/src/DsShared/Helpers/TitleLogicHelper.php
+++ b/src/DsShared/Helpers/TitleLogicHelper.php
@@ -47,7 +47,9 @@ class TitleLogicHelper
         $count = count($ancestryArray);
         if ($count === 0) {
             throw new RuntimeException("Programme::getAncestry appears to have returned nothing. This should not be possible");
-        } elseif ($count === 1) {
+        }
+
+        if ($count === 1) {
             // no ancestors. Title must be the item title
             $mainTitleProgramme = reset($ancestryArray);
         } elseif ($titleFormat === 'item::ancestry') {


### PR DESCRIPTION
When writing code with early returns inside an if statement there is no
point carrying on in an else or an elseif - either write logic or have
a second if statement.