### PR TITLE
Remove the 'sponsor' advert slot

### DIFF
--- a/app/Resources/views/find_by_pid/tlec.html.twig
+++ b/app/Resources/views/find_by_pid/tlec.html.twig
@@ -3,7 +3,7 @@
 {% block html_classes %}b-pw-1280{% endblock %}
 {% block page_classes %}gel-long-primer amen{% endblock %}
 {% block title %}{{ meta_context.titlePrefix() }}{% endblock %}
-{% block adsToDisplay %}leaderboard mpu sponsor{% endblock %}
+{% block adsToDisplay %}leaderboard mpu{% endblock %}
 
 {% block body %}
     {# TODO Leaderboard Advert #}

--- a/src/Branding/BrandingPlaceholderResolver.php
+++ b/src/Branding/BrandingPlaceholderResolver.php
@@ -17,8 +17,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * correct per-programme Title and Navigation?
  *
  * This is solved by the Branding Tool outputting templates that contain
- * placeholder sections such as  <!--BRANDING_PLACEHOLDER_TITLE--> and
- * <!--BRANDING_PLACEHOLDER_NAV--> when there is not programme set.
+ * placeholder sections such as <!--BRANDING_PLACEHOLDER_TITLE--> and
+ * <!--BRANDING_PLACEHOLDER_NAV--> when there is no programme set.
  *
  * This takes a Branding instance that contains those placeholders and a
  * "context" and replaces those placeholders with a title and default
@@ -28,7 +28,6 @@ class BrandingPlaceholderResolver
 {
     private const PLACEHOLDER_TITLE = '<!--BRANDING_PLACEHOLDER_TITLE-->';
     private const PLACEHOLDER_NAV = '<!--BRANDING_PLACEHOLDER_NAV-->';
-    private const PLACEHOLDER_SPONSOR = '<!--BRANDING_PLACEHOLDER_SPONSOR-->';
 
     /** @var UrlGeneratorInterface */
     private $router;
@@ -81,15 +80,6 @@ class BrandingPlaceholderResolver
             $haystack = str_replace(
                 self::PLACEHOLDER_NAV,
                 $this->buildNav($context, $branding),
-                $haystack
-            );
-        }
-
-        // Sponsor
-        if (strpos($haystack, self::PLACEHOLDER_SPONSOR) !== 0) {
-            $haystack = str_replace(
-                self::PLACEHOLDER_SPONSOR,
-                $this->buildSponsor($context),
                 $haystack
             );
         }
@@ -162,11 +152,5 @@ class BrandingPlaceholderResolver
         }
 
         return implode('', $navItems);
-    }
-
-    private function buildSponsor($context): string
-    {
-        // TODO
-        return '';
     }
 }

--- a/tests/Branding/BrandingPlaceholderResolverTest.php
+++ b/tests/Branding/BrandingPlaceholderResolverTest.php
@@ -130,7 +130,7 @@ class BrandingPlaceholderResolverTest extends TestCase
     {
         return new Branding(
             '<branding-head/>',
-            '<branding-bodyfirst><!--BRANDING_PLACEHOLDER_TITLE-->||<!--BRANDING_PLACEHOLDER_NAV-->||<!--BRANDING_PLACEHOLDER_SPONSOR--></branding-bodyfirst>',
+            '<branding-bodyfirst><!--BRANDING_PLACEHOLDER_TITLE-->||<!--BRANDING_PLACEHOLDER_NAV--></branding-bodyfirst>',
             '<branding-bodylast/>',
             ['body' => ['bg' => '#eeeeee']],
             []


### PR DESCRIPTION
AdOps have confirmed that the sponsor block shall not be sold again, so
there is no need to have a sponsor placeholder.