### PR TITLE
Fix autowiring deprecation messages

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -105,6 +105,7 @@ csa_guzzle:
     logger: true
     clients:
         default:
+            alias: 'GuzzleHttp\ClientInterface'
             config:
                 cert: '/etc/pki/dev.bbc.co.uk.pem'
                 ssl_key: '/etc/pki/dev.bbc.co.uk.pem'

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -38,6 +38,7 @@ monolog:
 csa_guzzle:
     clients:
         default:
+            alias: 'GuzzleHttp\ClientInterface'
             config:
                 cert: '/etc/pki/tls/certs/client.crt'
                 ssl_key: '/etc/pki/tls/private/client.key'

--- a/src/ExternalApi/RecEng/Service/RecEngService.php
+++ b/src/ExternalApi/RecEng/Service/RecEngService.php
@@ -11,7 +11,7 @@ use BBC\ProgrammesPagesService\Domain\Entity\Programme;
 use BBC\ProgrammesPagesService\Domain\Entity\ProgrammeContainer;
 use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 use BBC\ProgrammesPagesService\Service\ProgrammesService;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use InvalidArgumentException;
@@ -26,7 +26,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class RecEngService
 {
-    /** @var Client */
+    /** @var ClientInterface */
     private $client;
 
     /** @var string */
@@ -48,7 +48,7 @@ class RecEngService
     private $cache;
 
     public function __construct(
-        Client $client,
+        ClientInterface $client,
         string $audioKey,
         string $videoKey,
         ProgrammesService $programmesService,


### PR DESCRIPTION
Explicitly add a "GuzzleHttp\ClientInterface" service which is aliased
to the guzzle client we create. This means we are now doing explict
autowiring based on service names rather than implicit (based on types,
which is deprecated)

/cc @felipeparaujo 