### PR TITLE
Add Ada top topics to Brand page

### DIFF
--- a/config/routes/3rd_party.yaml
+++ b/config/routes/3rd_party.yaml
@@ -102,6 +102,19 @@ programme_recipes:
     requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
     schemes: [http]
 
+programme_topics:
+    path: /programmes/{pid}/topics
+    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
+    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
+    schemes: [http]
+
+programme_topics_topic:
+    path: /programmes/{pid}/topics/{topic}
+    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
+    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
+    schemes: [http]
+
+
 # TODO implement slice and filter parameters properly
 programme_broadcasts:
     path: /programmes/{pid}/broadcasts/
@@ -119,4 +132,15 @@ programme_upcoming_debut_broadcasts:
     path: /programmes/{pid}/broadcasts/upcoming/debut
     defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
     requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
+    schemes: [http]
+
+
+topics:
+    path: /programmes/topics
+    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
+    schemes: [http]
+
+topics_topic:
+    path: /programmes/topics/{topic}
+    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
     schemes: [http]

--- a/src/Controller/FindByPid/TlecController.php
+++ b/src/Controller/FindByPid/TlecController.php
@@ -99,12 +99,11 @@ class TlecController extends BaseController
         $supportingContentItems = $electronService->fetchSupportingContentItemsForProgramme($programme);
 
         $relatedTopics = [];
-        // TODO uncomment me when it is time to render ADA content
-        // if ($programme->getOption('show_enhanced_navigation')) {
-        //     // Less than 50 episodes (through ancestry)...
-        //     $usePerContainerValues = $programme->getAggregatedEpisodesCount() >= 50;
-        //     $relatedTopics = $adaClassService->findRelatedClassesByContainer($programme, $usePerContainerValues);
-        // }
+        if ($programme->getOption('show_enhanced_navigation')) {
+            // Less than 50 episodes (through ancestry)...
+            $usePerContainerValues = $programme->getAggregatedEpisodesCount() >= 50;
+            $relatedTopics = $adaClassService->findRelatedClassesByContainer($programme, $usePerContainerValues);
+        }
 
         $mapPresenter = $presenterFactory->mapPresenter(
             $programme,

--- a/src/DsAmen/PresenterFactory.php
+++ b/src/DsAmen/PresenterFactory.php
@@ -12,9 +12,11 @@ use App\DsAmen\Presenters\Domain\RelatedLink\RelatedLinkPresenter;
 use App\DsAmen\Presenters\Domain\SupportingContent\SupportingContentPresenter;
 use App\DsAmen\Presenters\Section\Footer\FooterPresenter;
 use App\DsAmen\Presenters\Section\Map\MapPresenter;
+use App\DsAmen\Presenters\Section\RelatedTopics\RelatedTopicsPresenter;
 use App\DsAmen\Presenters\Utilities\Duration\DurationPresenter;
 use App\DsAmen\Presenters\Utilities\Synopsis\SynopsisPresenter;
 use App\DsShared\Helpers\HelperFactory;
+use App\ExternalApi\Ada\Domain\AdaClass;
 use App\ExternalApi\Electron\Domain\SupportingContentItem;
 use App\ExternalApi\Recipes\Domain\Recipe;
 use App\Translate\TranslateProvider;
@@ -54,43 +56,9 @@ class PresenterFactory
         return new DurationPresenter($duration, $this->translateProvider, $options);
     }
 
-    public function mapPresenter(
-        ProgrammeContainer $programme,
-        ?CollapsedBroadcast $upcomingBroadcast,
-        ?CollapsedBroadcast $lastOn,
-        ?Promotion $firstPromo,
-        ?Promotion $comingSoonPromo,
-        ?Episode $streamableEpisode,
-        int $debutsCount,
-        int $repeatsCount,
-        bool $isPromoPriority,
-        bool $showMiniMap
-    ): MapPresenter {
-        return new MapPresenter(
-            $this->helperFactory,
-            $this->translateProvider,
-            $this->router,
-            $programme,
-            $upcomingBroadcast,
-            $lastOn,
-            $firstPromo,
-            $comingSoonPromo,
-            $streamableEpisode,
-            $debutsCount,
-            $repeatsCount,
-            $isPromoPriority,
-            $showMiniMap
-        );
-    }
-
     public function collapsedBroadcastPresenter(CollapsedBroadcast $collapsedBroadcast, array $options = []): CollapsedBroadcastPresenter
     {
         return new CollapsedBroadcastPresenter($collapsedBroadcast, $this->router, $this->translateProvider, $this->helperFactory, $options);
-    }
-
-    public function footerPresenter(Programme $programme, array $options = []): FooterPresenter
-    {
-        return new FooterPresenter($programme, $options);
     }
 
     public function groupPresenter(Group $group, array $options = []): GroupPresenter
@@ -126,5 +94,49 @@ class PresenterFactory
     public function recipePresenter(Recipe $recipe, array $options = []): RecipePresenter
     {
         return new RecipePresenter($recipe, $options);
+    }
+
+
+    public function footerPresenter(Programme $programme, array $options = []): FooterPresenter
+    {
+        return new FooterPresenter($programme, $options);
+    }
+
+    public function mapPresenter(
+        ProgrammeContainer $programme,
+        ?CollapsedBroadcast $upcomingBroadcast,
+        ?CollapsedBroadcast $lastOn,
+        ?Promotion $firstPromo,
+        ?Promotion $comingSoonPromo,
+        ?Episode $streamableEpisode,
+        int $debutsCount,
+        int $repeatsCount,
+        bool $isPromoPriority,
+        bool $showMiniMap
+    ): MapPresenter {
+        return new MapPresenter(
+            $this->helperFactory,
+            $this->translateProvider,
+            $this->router,
+            $programme,
+            $upcomingBroadcast,
+            $lastOn,
+            $firstPromo,
+            $comingSoonPromo,
+            $streamableEpisode,
+            $debutsCount,
+            $repeatsCount,
+            $isPromoPriority,
+            $showMiniMap
+        );
+    }
+
+    /**
+     * @param AdaClass[] $adaClasses
+     * @param array $options
+     */
+    public function relatedTopicsPresenter(array $adaClasses, array $options = []): RelatedTopicsPresenter
+    {
+        return new RelatedTopicsPresenter($adaClasses, $options);
     }
 }

--- a/src/DsAmen/Presenters/Section/RelatedTopics/RelatedTopicsPresenter.php
+++ b/src/DsAmen/Presenters/Section/RelatedTopics/RelatedTopicsPresenter.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types = 1);
+
+namespace App\DsAmen\Presenters\Section\RelatedTopics;
+
+use App\DsAmen\Presenter;
+use App\ExternalApi\Ada\Domain\AdaClass;
+
+class RelatedTopicsPresenter extends Presenter
+{
+    /** @var AdaClass[] */
+    private $adaClasses;
+
+    public function __construct(array $adaClasses, array $options = [])
+    {
+        parent::__construct($options);
+        $this->adaClasses = $adaClasses;
+    }
+
+    /** @return AdaClass[] */
+    public function getAdaClasses(): array
+    {
+        return $this->adaClasses;
+    }
+}

--- a/src/DsAmen/Presenters/Section/RelatedTopics/_related-topics.scss
+++ b/src/DsAmen/Presenters/Section/RelatedTopics/_related-topics.scss
@@ -1,0 +1,41 @@
+.related-topics {
+    // Bottom padding is less to account for the spacing that occurs due to the
+    // margin-bottom on the individual li items
+    padding: 8px 8px 0;
+    margin-bottom: 8px;
+
+    line-height: 1;
+    // Remove whitespace caused by `inline-block`.
+    letter-spacing: -0.31em;
+    word-spacing: -0.43em;
+
+    @include mq($from: gel3) {
+        padding: 16px 16px 8px;
+        margin-bottom: 16px;
+    }
+}
+
+.related-topics li {
+    display: inline-block;
+    list-style: none;
+    margin-right: 8px;
+    margin-bottom: 8px;
+
+    letter-spacing: normal;
+    word-spacing: normal;
+}
+
+.related-topics li:last-child {
+    margin-right: 0;
+}
+
+.related-topics a {
+    display: block;
+    padding: 11px;
+    border-width: 1px;
+    border-style: solid;
+}
+
+.related-topics__title {
+    font-weight: bold;
+}

--- a/src/DsAmen/Presenters/Section/RelatedTopics/related_topics.html.twig
+++ b/src/DsAmen/Presenters/Section/RelatedTopics/related_topics.html.twig
@@ -1,0 +1,9 @@
+<div class="br-box-secondary">
+    <h2 class="gel-double-pica-bold island">{{ tr('top_topics') }}</h2>
+    <ol class="related-topics br-keyline media__meta-row--separator">
+        {%- for adaClass in related_topics.getAdaClasses() -%}
+            {%- set url = path(adaClass.getProgrammeItemCountContext() ? 'programme_topics_topic' : 'topics_topic', {pid: adaClass.getProgrammeItemCountContext(), topic: adaClass.getId()}) -%}
+            <li><a class="br-linkinvert" href="{{ url }}" data-linktrack="brand_topic"><span class="related-topics__title">{{ adaClass.getTitle() }}</span> ({{ adaClass.getProgrammeItemCount()}})</a></li>
+        {%- endfor -%}
+    </ol>
+</div>

--- a/src/DsAmen/_dsAmen-components.scss
+++ b/src/DsAmen/_dsAmen-components.scss
@@ -72,4 +72,5 @@ $ie: false !default;
 //@import 'Organism/RmpCard/rmpcard';
 @import 'Presenters/Section/Map/map';
 @import 'Presenters/Section/Footer/footer';
+@import 'Presenters/Section/RelatedTopics/related-topics';
 @import 'Presenters/Domain/SupportingContent/supporting-content';

--- a/src/ExternalApi/Ada/Domain/AdaClass.php
+++ b/src/ExternalApi/Ada/Domain/AdaClass.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\ExternalApi\Ada\Domain;
 
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 
 /**
  * Ada Provides Classes, which are overarching containers that things may be
@@ -23,7 +24,10 @@ class AdaClass
     private $title;
 
     /** @var int */
-    private $episodeCount;
+    private $programmeItemCount;
+
+    /** @var Pid */
+    private $programmeItemCountContext;
 
     /** @var Image */
     private $image;
@@ -31,12 +35,14 @@ class AdaClass
     public function __construct(
         string $id,
         string $title,
-        int $episodeCount,
+        int $programmeItemCount,
+        ?Pid $programmeItemCountContext,
         Image $image
     ) {
         $this->id = $id;
         $this->title = $title;
-        $this->episodeCount = $episodeCount;
+        $this->programmeItemCount = $programmeItemCount;
+        $this->programmeItemCountContext = $programmeItemCountContext;
         $this->image = $image;
     }
 
@@ -50,9 +56,14 @@ class AdaClass
         return $this->title;
     }
 
-    public function getEpisodeCount(): int
+    public function getProgrammeItemCount(): int
     {
-        return $this->episodeCount;
+        return $this->programmeItemCount;
+    }
+
+    public function getProgrammeItemCountContext(): ?Pid
+    {
+        return $this->programmeItemCountContext;
     }
 
     public function getImage(): Image

--- a/src/ExternalApi/Ada/Mapper/AdaClassMapper.php
+++ b/src/ExternalApi/Ada/Mapper/AdaClassMapper.php
@@ -9,12 +9,13 @@ use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
 
 class AdaClassMapper
 {
-    public function mapItem(array $adaClass): AdaClass
+    public function mapItem(array $adaClass, ?string $countContextPid): AdaClass
     {
         return new AdaClass(
             $adaClass['id'],
             $adaClass['title'],
             $adaClass['programme_items_count'],
+            $countContextPid ? new Pid($countContextPid) : null,
             $this->getImageModel($adaClass['image'])
         );
     }

--- a/templates/find_by_pid/tlec.html.twig
+++ b/templates/find_by_pid/tlec.html.twig
@@ -181,6 +181,12 @@
         </div>
     </div>
 
+    {% if relatedTopics %}
+        <div class="p-g-p">
+            {{ ds_amen('relatedTopics', relatedTopics) }}
+        </div>
+    {% endif %}
+
     {% if relatedLinks %}
         <div class="p-g-p">
             <div class="br-box-secondary">

--- a/tests/ExternalApi/Ada/Domain/AdaClassTest.php
+++ b/tests/ExternalApi/Ada/Domain/AdaClassTest.php
@@ -12,12 +12,14 @@ class AdaClassTest extends TestCase
 {
     public function testConstructor()
     {
+        $pid = new Pid('b0000001');
         $image = $this->createMock(Image::class);
-        $adaClass = new AdaClass('id', 'title', 1, $image);
+        $adaClass = new AdaClass('id', 'title', 1, $pid, $image);
 
         $this->assertEquals('id', $adaClass->getId());
         $this->assertEquals('title', $adaClass->getTitle());
-        $this->assertEquals(1, $adaClass->getEpisodeCount());
+        $this->assertEquals(1, $adaClass->getProgrammeItemCount());
+        $this->assertEquals($pid, $adaClass->getProgrammeItemCountContext());
         $this->assertEquals($image, $adaClass->getImage());
     }
 }

--- a/tests/ExternalApi/Ada/Mapper/AdaClassMapperTest.php
+++ b/tests/ExternalApi/Ada/Mapper/AdaClassMapperTest.php
@@ -27,9 +27,33 @@ class AdaClassMapperTest extends TestCase
             'Fellows_of_the_Royal_Society',
             'Fellows of the Royal Society',
             16,
+            new Pid('b0000001'),
             new Image(new Pid('p01l7xx5'), '', '', '', '', 'jpg')
         );
 
-        $this->assertEquals($expectedEntity, $mapper->mapItem($adaEntity));
+        $this->assertEquals($expectedEntity, $mapper->mapItem($adaEntity, 'b0000001'));
+    }
+
+    public function testMapItemWithNullContext()
+    {
+        $adaEntity = [
+            'id' => 'Fellows_of_the_Royal_Society',
+            'type' => 'category',
+            'title' => 'Fellows of the Royal Society',
+            'image' => 'ichef.bbci.co.uk/images/ic/$recipe/p01l7xx5.jpg',
+            'programme_items_count' => 16,
+        ];
+
+        $mapper = new AdaClassMapper();
+
+        $expectedEntity = new AdaClass(
+            'Fellows_of_the_Royal_Society',
+            'Fellows of the Royal Society',
+            16,
+            null,
+            new Image(new Pid('p01l7xx5'), '', '', '', '', 'jpg')
+        );
+
+        $this->assertEquals($expectedEntity, $mapper->mapItem($adaEntity, null));
     }
 }


### PR DESCRIPTION
Use [In Our Time](http://www.bbc.co.uk/programmes/b006qykl) as an example. 

Eventually we'll need to update to make the tracking link location and the visibility of count configurable when we do the episode page, but that can happen when we need those options.