### PR TITLE
No truncation by default in Amen Programme objects

### DIFF
--- a/src/Controller/Styleguide/Amen/Domain/ProgrammeController.php
+++ b/src/Controller/Styleguide/Amen/Domain/ProgrammeController.php
@@ -75,7 +75,7 @@ class ProgrammeController extends BaseController
                 'item' => $clipBuilderDefault->build(),
                 'render_options' => [
                     'title_options' => [
-                        'max_title_length' => 10,
+                        'truncation_length' => 10,
                     ],
                 ],
             ],

--- a/src/DsAmen/Presenters/Domain/CoreEntity/Base/SubPresenter/BaseTitlePresenter.php
+++ b/src/DsAmen/Presenters/Domain/CoreEntity/Base/SubPresenter/BaseTitlePresenter.php
@@ -36,7 +36,7 @@ abstract class BaseTitlePresenter extends Presenter
         'title_size_large' => 'gel-pica-bold',
         'title_size_small' => 'gel-pica',
         'branding_name' => 'subtle',
-        'max_title_length' => 60,
+        'truncation_length' => 60,
     ];
 
     public function __construct(
@@ -118,8 +118,8 @@ abstract class BaseTitlePresenter extends Presenter
             throw new InvalidOptionException('text_colour_on_title_link option must be a boolean');
         }
 
-        if (!is_int($options['max_title_length'])) {
-            throw new InvalidOptionException('max_title_length option must be an integer. HINT: use -1 for unlimited title length');
+        if (isset($options['truncation_length']) && !is_int($options['truncation_length'])) {
+            throw new InvalidOptionException('truncation_length option must be null or an integer. HINT: use null for unlimited title length');
         }
     }
 
@@ -135,7 +135,7 @@ abstract class BaseTitlePresenter extends Presenter
     private function truncate(string $string, string $suffix = '…'): string
     {
         $length = mb_strlen($string);
-        $maxLength = $this->getOption('max_title_length');
+        $maxLength = $this->getOption('truncation_length');
 
         if ($maxLength > 0 && $length > $maxLength) {
             return mb_substr($string, 0, mb_strrpos($string, ' ', $maxLength - $length)) . $suffix;

--- a/src/DsAmen/Presenters/Domain/CoreEntity/Base/SubPresenter/BaseTitlePresenter.php
+++ b/src/DsAmen/Presenters/Domain/CoreEntity/Base/SubPresenter/BaseTitlePresenter.php
@@ -36,7 +36,7 @@ abstract class BaseTitlePresenter extends Presenter
         'title_size_large' => 'gel-pica-bold',
         'title_size_small' => 'gel-pica',
         'branding_name' => 'subtle',
-        'truncation_length' => 60,
+        'truncation_length' => null,
     ];
 
     public function __construct(

--- a/src/DsAmen/Presenters/Section/Map/SubPresenter/last_on.html.twig
+++ b/src/DsAmen/Presenters/Section/Map/SubPresenter/last_on.html.twig
@@ -12,7 +12,8 @@
                 'link_location_prefix': 'map_laston_',
                 'title_options': {
                     'title_size_large': 'gel-great-primer-bold',
-                    'title_size_small': 'gel-pica'
+                    'title_size_small': 'gel-pica',
+                    'truncation_length': 60,
                 },
                 'body_options': {
                     'show_synopsis': false,

--- a/src/DsAmen/Presenters/Section/Map/SubPresenter/on_demand.html.twig
+++ b/src/DsAmen/Presenters/Section/Map/SubPresenter/on_demand.html.twig
@@ -26,7 +26,8 @@
         'link_location_prefix': 'map_ondemand_',
         'title_options': {
             'text_colour_on_title_link': false,
-            'title_size_large': 'gel-great-primer-bold'
+            'title_size_large': 'gel-great-primer-bold',
+            'truncation_length': 60,
         },
         'image_options': {
             'badge_text': tr(presenter.getBadgeTranslationString()),

--- a/src/DsAmen/Presenters/Section/Map/SubPresenter/tx.html.twig
+++ b/src/DsAmen/Presenters/Section/Map/SubPresenter/tx.html.twig
@@ -13,7 +13,8 @@
                 'title_options': {
                     'title_size_large': 'gel-great-primer-bold',
                     'title_size_small': 'gel-pica',
-                    'text_colour_on_title_link': false
+                    'text_colour_on_title_link': false,
+                    'truncation_length': 60,
                 },
                 'body_options': {
                     'show_synopsis': false,

--- a/tests/DsAmen/Presenters/Domain/CoreEntity/Shared/SubPresenter/TitlePresenterTest.php
+++ b/tests/DsAmen/Presenters/Domain/CoreEntity/Shared/SubPresenter/TitlePresenterTest.php
@@ -230,7 +230,7 @@ class TitlePresenterTest extends BaseSubPresenterTest
         return [
             'Non-boolean value for text_colour_on_title_link' => [['text_colour_on_title_link' => null]],
             'Non-core entity and non-null value for context_programme' => [['context_programme' => 1]],
-            'Non-integer value for max_title_length' => [['max_title_length' => 'a']],
+            'Non-integer and non-null value for truncation_length' => [['truncation_length' => 'a']],
         ];
     }
 }

--- a/tests/DsAmen/Presenters/Domain/CoreEntity/Shared/SubPresenter/TitlePresenterTest.php
+++ b/tests/DsAmen/Presenters/Domain/CoreEntity/Shared/SubPresenter/TitlePresenterTest.php
@@ -145,6 +145,7 @@ class TitlePresenterTest extends BaseSubPresenterTest
             [
                 'context_programme' => $this->mockContext,
                 'title_format' => 'item::ancestry',
+                'truncation_length' => 60,
             ]
         );
 
@@ -171,6 +172,7 @@ class TitlePresenterTest extends BaseSubPresenterTest
             [
                 'context_programme' => $this->mockContext,
                 'title_format' => 'item::ancestry',
+                'truncation_length' => 60,
             ]
         );
 


### PR DESCRIPTION
The DsAmen behaviour now matches the Ds2013 programme object.

I've renamed the option to 'truncation_length' to match the name used by the Ds2013 programme object.

Programmes/Broadcasts in the MAP should still be truncated to 60 chars explicitly.