### PR TITLE
Add skeleton for /programmes/:pid/episodes/player

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -22,10 +22,19 @@ find_by_pid:
     defaults: { _controller: '!find_by_pid' }
     requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
 
+# Programme information pages
+
+programme_episodes_player:
+    path: /programmes/{pid}/episodes/player
+    defaults: { _controller: App\Controller\ProgrammeEpisodes\PlayerController }
+    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
+
 partial_programme_recipes:
     path: /programmes/{pid}/recipes.ameninc
     defaults: { _controller: App\Controller\Partial\RecipesController }
     requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
+
+# Schedules
 
 schedules_home:
     path: /schedules

--- a/config/routes/3rd_party.yaml
+++ b/config/routes/3rd_party.yaml
@@ -78,12 +78,6 @@ programme_episodes_guide:
     requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
     schemes: [http]
 
-programme_episodes_player:
-    path: /programmes/{pid}/episodes/player
-    defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }
-    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
-    schemes: [http]
-
 programme_clips:
     path: /programmes/{pid}/clips
     defaults: { _controller: FrameworkBundle:Redirect:redirect, route: '' }

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -84,6 +84,25 @@ abstract class BaseController extends AbstractController
         return $this->canonicalUrl;
     }
 
+    protected function getPage(): int
+    {
+        $pageString = $this->request()->query->get(
+            'page',
+            '1'
+        );
+
+        if (ctype_digit($pageString)) {
+            $page = (int) $pageString;
+            // Have a controlled upper-bound to stop people putting in clearly
+            // absurdly large page sizes
+            if ($page >= 1 && $page <= 9999) {
+                return $page;
+            }
+        }
+
+        throw $this->createNotFoundException('Page parameter must be a number between 1 and 9999');
+    }
+
     protected function setBrandingId(string $brandingId)
     {
         $this->brandingId = $brandingId;

--- a/src/Controller/ProgrammeEpisodes/PlayerController.php
+++ b/src/Controller/ProgrammeEpisodes/PlayerController.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types = 1);
+namespace App\Controller\ProgrammeEpisodes;
+
+use App\Controller\BaseController;
+use BBC\ProgrammesPagesService\Domain\Entity\ProgrammeContainer;
+use BBC\ProgrammesPagesService\Service\ProgrammesAggregationService;
+
+class PlayerController extends BaseController
+{
+    public function __invoke(
+        ProgrammeContainer $programme,
+        ProgrammesAggregationService $programmeAggregationService
+    ) {
+        $this->setContext($programme);
+        $page = $this->getPage();
+        $limit = 10;
+
+        $availableEpisodes = $programmeAggregationService->findStreamableOnDemandEpisodes(
+            $programme,
+            $limit,
+            $page
+        );
+
+        // If you visit an out-of-bounds page then throw a 404. Page one should
+        // always be a 200 so search engines don't drop their reference to the
+        // page while a programme is off-air
+        if (!$availableEpisodes && $page !== 1) {
+            throw $this->createNotFoundException('Page does not exist');
+        }
+
+        return $this->renderWithChrome('programme_episodes/player.html.twig', [
+            'programme' => $programme,
+            'availableEpisodes' => $availableEpisodes,
+        ]);
+    }
+}

--- a/src/DsShared/PresenterFactory.php
+++ b/src/DsShared/PresenterFactory.php
@@ -3,7 +3,9 @@ declare(strict_types = 1);
 
 namespace App\DsShared;
 
+use App\DsShared\Utilities\EntityContext\EntityContextPresenter;
 use App\DsShared\Utilities\Image\ImagePresenter;
+use BBC\ProgrammesPagesService\Domain\Entity\CoreEntity;
 use BBC\ProgrammesPagesService\Domain\Entity\Image;
 
 /**
@@ -11,6 +13,13 @@ use BBC\ProgrammesPagesService\Domain\Entity\Image;
  */
 class PresenterFactory
 {
+    public function entityContextPresenter(
+        CoreEntity $context,
+        array $options = []
+    ): EntityContextPresenter {
+        return new EntityContextPresenter($context, $options);
+    }
+
     public function imagePresenter(
         Image $image,
         int $defaultWidth,

--- a/src/DsShared/Utilities/EntityContext/EntityContextPresenter.php
+++ b/src/DsShared/Utilities/EntityContext/EntityContextPresenter.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types = 1);
+namespace App\DsShared\Utilities\EntityContext;
+
+use App\DsShared\Presenter;
+use BBC\ProgrammesPagesService\Domain\Entity\CoreEntity;
+
+class EntityContextPresenter extends Presenter
+{
+    /** @var CoreEntity[] */
+    private $ancestry;
+
+    public function __construct(
+        CoreEntity $entity,
+        array $options = []
+    ) {
+        parent::__construct($options);
+        $this->ancestry = array_reverse($entity->getAncestry());
+    }
+
+    public function getAncestry(): array
+    {
+        return $this->ancestry;
+    }
+}

--- a/src/DsShared/Utilities/EntityContext/entity_context.html.twig
+++ b/src/DsShared/Utilities/EntityContext/entity_context.html.twig
@@ -1,0 +1,7 @@
+<span class="context">
+{%- for item in entity_context.getAncestry() -%}
+    <a class="context__item" href="{{ path('find_by_pid', {'pid': item.getPid()}) }}">{{ item.getTitle() }}</a>
+    {{- not loop.last ? (loop.first ? ' ' : ', ') -}}
+{%- endfor -%}
+</span>
+{#- I am a comment with whitespace supression so a newline is not rendered at the end of this template -#}

--- a/templates/programme_episodes/player.html.twig
+++ b/templates/programme_episodes/player.html.twig
@@ -1,0 +1,28 @@
+{% extends 'base_ds2013.html.twig' %}
+
+{% block title %}{{ meta_context.titlePrefix() }} - {{ tr('available_now') }}{% endblock %}
+{% block page_classes %}text-base programmes-page programmes-page--smallpush b-g-p{% endblock %}
+
+{% block body %}
+<div class="island br-box-secondary">
+    <h1>{{ds_shared('entityContext', programme)}} {{ tr('episodes') }} <span class="visually-hidden">{{ tr('available_now') }}</span></h1>
+</div>
+
+<div class="br-box-page programmes-page">
+    {% if availableEpisodes %}
+        <ol class="highlight-box-wrapper">
+        {% for episode in availableEpisodes %}
+            {{ ds2013('programme', episode, {
+                'context_programme': programme,
+                'highlight_box_classes': 'highlight-box--list',
+                title_options: {
+                    'title_format': 'item::ancestry',
+                }
+            }) }}
+        {% endfor %}
+        </ol>
+    {% else %}
+        <p class="note island">{{ tr('available_count', 0)}}</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/tests/BaseTemplateTestCase.php
+++ b/tests/BaseTemplateTestCase.php
@@ -19,11 +19,15 @@ abstract class BaseTemplateTestCase extends TestCase
         }
     }
 
+    protected function presenterHtml(BasePresenter $presenter): string
+    {
+        return self::$twig->loadTemplate($presenter->getTemplatePath())->render([
+            $presenter->getTemplateVariableName() => $presenter,
+        ]);
+    }
+
     /**
-     * Get a Dom Crawler populated with a given Twig template.
-     *
-     * @param string $name    The template name
-     * @param array  $context An array of parameters to pass to the template
+     * Get a Dom Crawler populated with the output of a template.
      *
      * @return Crawler The Dom Crawler populated with the twig template
      *
@@ -31,18 +35,9 @@ abstract class BaseTemplateTestCase extends TestCase
      * @throws Twig_Error_Syntax  When an error occurred during compilation
      * @throws Twig_Error_Runtime When an error occurred during rendering
      */
-    protected function crawler(string $name, array $context = []): Crawler
-    {
-        return new Crawler(
-            self::$twig->loadTemplate($name)->render($context)
-        );
-    }
-
     protected function presenterCrawler(BasePresenter $presenter): Crawler
     {
-        return $this->crawler($presenter->getTemplatePath(), [
-            $presenter->getTemplateVariableName() => $presenter,
-        ]);
+        return new Crawler($this->presenterHtml($presenter));
     }
 
     protected function assertHasClasses(string $expectedClasses, Crawler $node, $message): void

--- a/tests/DsShared/Utilities/EntityContext/EntityContextTemplateTest.php
+++ b/tests/DsShared/Utilities/EntityContext/EntityContextTemplateTest.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\App\DsShared\Utilities\EntityContext;
+
+use BBC\ProgrammesPagesService\Domain\Entity\CoreEntity;
+use BBC\ProgrammesPagesService\Domain\ValueObject\Pid;
+use Tests\App\BaseTemplateTestCase;
+use Tests\App\TwigEnvironmentProvider;
+
+class EntityContextTemplateTest extends BaseTemplateTestCase
+{
+    /**
+     * @dataProvider entityContextDataProvider
+     */
+    public function testEntityContext($entity, $expectedOutput)
+    {
+        $presenterFactory = TwigEnvironmentProvider::dsSharedPresenterFactory();
+        $presenter = $presenterFactory->entityContextPresenter($entity);
+        $html = $this->presenterHtml($presenter);
+
+        $this->assertEquals($expectedOutput, $html);
+    }
+
+    public function entityContextDataProvider()
+    {
+        $greatGrandparent = $this->buildMockCoreEntity('b0000001', 'great-grandparent', []);
+        $grandparent = $this->buildMockCoreEntity('b0000002', 'grandparent', [$greatGrandparent]);
+        $parent = $this->buildMockCoreEntity('b0000003', 'parent', [$grandparent, $greatGrandparent]);
+        $child = $this->buildMockCoreEntity('b0000004', 'child', [$parent, $grandparent, $greatGrandparent]);
+
+        return [
+            'one item' => [$greatGrandparent, '<span class="context"><a class="context__item" href="/programmes/b0000001">great-grandparent</a></span>'],
+            'two items' => [$grandparent, '<span class="context"><a class="context__item" href="/programmes/b0000001">great-grandparent</a> <a class="context__item" href="/programmes/b0000002">grandparent</a></span>'],
+            'three items' => [$parent, '<span class="context"><a class="context__item" href="/programmes/b0000001">great-grandparent</a> <a class="context__item" href="/programmes/b0000002">grandparent</a>, <a class="context__item" href="/programmes/b0000003">parent</a></span>'],
+            'four items' => [$child, '<span class="context"><a class="context__item" href="/programmes/b0000001">great-grandparent</a> <a class="context__item" href="/programmes/b0000002">grandparent</a>, <a class="context__item" href="/programmes/b0000003">parent</a>, <a class="context__item" href="/programmes/b0000004">child</a></span>'],
+        ];
+    }
+
+    private function buildMockCoreEntity(string $pid, string $title, array $parents)
+    {
+        $programme = $this->createMock(CoreEntity::class);
+        $programme->method('getPid')->willReturn(new Pid($pid));
+        $programme->method('getTitle')->willReturn($title);
+        $programme->method('getAncestry')->willReturn(array_merge([$programme], $parents));
+
+        return $programme;
+    }
+}

--- a/tests/Twig/HtmlUtilitiesExtensionTest.php
+++ b/tests/Twig/HtmlUtilitiesExtensionTest.php
@@ -4,14 +4,12 @@ namespace Tests\App\Twig;
 
 use App\Twig\HtmlUtilitiesExtension;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Symfony\Component\Asset\Packages;
 
 class HtmlUtilitiesExtensionTest extends TestCase
 {
     public function testAssetJs()
     {
-        /** @var Packages|PHPUnit_Framework_MockObject_MockObject $mockPackages */
         $mockPackages = $this->createMock(Packages::class);
         $mockPackages->expects($this->once())->method('getUrl')
             ->with('some/example/path.js')


### PR DESCRIPTION
Move the route into the main routes.yaml, adds a controller and view and
builds the context titling.

Fixes PROGRAMMES-6140 and PROGRAMMES-6137

---

There's a ProgrammeEpisodes namespace there because there's about 6 or so routes that hang off /programmes/:pid/episodes so grouping them would be handy.

I should probably start some controller tests for this but it feels like slightly early days given its still missing the subnav and pagination