### PR TITLE
Ensure Redirect handling is optimised

### DIFF
--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -3,10 +3,8 @@ monolog:
         main:
             type: fingers_crossed
             channels: ['!app_access']
-            action_level: error
+            activation_strategy: '@App\Exception\Handler\HttpCodeActivationStrategy'
             handler: nested
-            excluded_404s:
-                - ^/
         app_access:
             type: stream
             channels: ['app_access']
@@ -19,3 +17,10 @@ monolog:
         console:
             type: console
             process_psr_3_messages: false
+
+
+services:
+    App\Exception\Handler\HttpCodeActivationStrategy:
+        arguments:
+            excludedCodes: [301, 302, 404]
+            actionLevel: error

--- a/src/Controller/ExceptionController.php
+++ b/src/Controller/ExceptionController.php
@@ -47,6 +47,12 @@ class ExceptionController extends BaseExceptionController
         $code = $exception->getStatusCode();
         $orb = $branding = null; //No need for Orb or Branding when developing locally
 
+        // If this is a Redirect exception don't return any body or show the
+        // debug page, just redirect everything
+        if ($code >= 300 && $code < 400) {
+            return new Response('', $code, $exception->getHeaders());
+        }
+
         if (!$showException) {
             try {
                 $branding = $this->brandingClient->getContent('br-00001');
@@ -76,6 +82,7 @@ class ExceptionController extends BaseExceptionController
         if (!$showException && $code >= 400 && $code <= 499) {
             $headers['Cache-Control'] = 'public, max-age=60';
         }
+
         // The 200 status here is a misnomer, it is a default and shall be
         // overridden later.
         return new Response($this->twig->render(

--- a/src/Exception/Handler/HttpCodeActivationStrategy.php
+++ b/src/Exception/Handler/HttpCodeActivationStrategy.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Exception\Handler;
+
+use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Activation strategy that ignores certain HTTP codes.
+ */
+class HttpCodeActivationStrategy extends ErrorLevelActivationStrategy
+{
+    private $excludedCodes;
+    private $requestStack;
+
+    public function __construct(RequestStack $requestStack, array $excludedCodes, $actionLevel)
+    {
+        parent::__construct($actionLevel);
+
+        $this->requestStack = $requestStack;
+        $this->excludedCodes = $excludedCodes;
+    }
+
+    public function isHandlerActivated(array $record)
+    {
+        $isActivated = parent::isHandlerActivated($record);
+
+        if ($isActivated && isset($record['context']['exception']) && $record['context']['exception'] instanceof HttpException) {
+            return !in_array($record['context']['exception']->getStatusCode(), $this->excludedCodes);
+        }
+
+        return $isActivated;
+    }
+}

--- a/src/Exception/ProgrammeOptionsRedirectHttpException.php
+++ b/src/Exception/ProgrammeOptionsRedirectHttpException.php
@@ -6,7 +6,10 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * Symfony provides several exceptions that result in the Framework emiting a
- * response, but it doesn't provide one for 301/302 redirects.
+ * response, but it doesn't provide one for 301/302 redirects - which is
+ * reasonable as they're not exceptions.
+ * However for us it is useful to eject out of code to trigger a redirect in a
+ * few places, notably when triggering programme options redirects.
  *
  * This Exception takes a location and status code, and shall send a redirect
  * request to that location. This being an exception allows us to trigger the

--- a/tests/Controller/PidOverrideHandlerTest.php
+++ b/tests/Controller/PidOverrideHandlerTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types = 1);
+namespace Tests\App\Controller;
+
+use BBC\ProgrammesPagesService\Domain\Entity\CoreEntity;
+use BBC\ProgrammesPagesService\Domain\Entity\Options;
+use BBC\ProgrammesPagesService\Service\CoreEntitiesService;
+use BBC\ProgrammesPagesService\Service\ServiceFactory;
+use Tests\App\BaseWebTestCase;
+
+/**
+ * This test asserts that Programmes with redirects configured in their options
+ * trigger those redirects, and that those redirects are cached.
+ */
+class PidOverrideHandlerTest extends BaseWebTestCase
+{
+    /**
+     * @dataProvider redirectsDataProvider
+     */
+    public function testRedirectsFromFindByPidPage(string $url, int $redirectStatusCode, string $redirectLocation)
+    {
+        $coreEntity = $this->createConfiguredMock(CoreEntity::class, [
+            'getOptions' => new Options([
+                'pid_override_code' => $redirectStatusCode,
+                'pid_override_url' => $redirectLocation,
+            ]),
+        ]);
+
+        $service = $this->createConfiguredMock(CoreEntitiesService::class, [
+            'findByPidFull' => $coreEntity,
+        ]);
+
+        $serviceFactory = $this->createConfiguredMock(ServiceFactory::class, [
+            'getCoreEntitiesService' => $service,
+        ]);
+
+        $client = static::createClient();
+        $client->getContainer()->set(ServiceFactory::class, $serviceFactory);
+
+        $crawler = $client->request('GET', $url);
+
+        $this->assertRedirectTo($client, $redirectStatusCode, $redirectLocation);
+        $this->assertEquals('max-age=3600, public', $client->getResponse()->headers->get('Cache-Control'));
+    }
+
+    public function redirectsDataProvider()
+    {
+        return [
+            'redirect from find-by-pid page' => [
+                '/programmes/b0000001', 301, 'http://example.com/test',
+            ],
+            'redirect from aggregate page' => [
+                '/programmes/b0000001/episodes/player', 302, 'http://example.org/wibble',
+            ],
+        ];
+    }
+}

--- a/tests/Exception/Handler/HttpCodeActivationStrategyTest.php
+++ b/tests/Exception/Handler/HttpCodeActivationStrategyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\App\Exception\Handler;
+
+use App\Exception\Handler\HttpCodeActivationStrategy;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class HttpCodeActivationStrategyTest extends TestCase
+{
+    /**
+     * @dataProvider isActivatedProvider
+     */
+    public function testIsActivated($url, $record, $expected)
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(Request::create($url));
+
+        $strategy = new HttpCodeActivationStrategy($requestStack, array(403, 404, 405), Logger::WARNING);
+
+        $this->assertEquals($expected, $strategy->isHandlerActivated($record));
+    }
+
+    public function isActivatedProvider()
+    {
+        return array(
+            array('/test', array('level' => Logger::ERROR), true),
+            array('/foo',  array('level' => Logger::ERROR, 'context' => $this->getContextException(401)), true),
+            array('/foo',  array('level' => Logger::ERROR, 'context' => $this->getContextException(402)), true),
+            array('/foo',  array('level' => Logger::ERROR, 'context' => $this->getContextException(403)), false),
+            array('/foo',  array('level' => Logger::ERROR, 'context' => $this->getContextException(404)), false),
+            array('/foo',  array('level' => Logger::ERROR, 'context' => $this->getContextException(405)), false),
+            array('/foo',  array('level' => Logger::ERROR, 'context' => $this->getContextException(406)), true),
+            array('/foo',  array('level' => Logger::ERROR, 'context' => $this->getContextException(500)), true),
+        );
+    }
+
+    protected function getContextException($code)
+    {
+        return array('exception' => new HttpException($code));
+    }
+}


### PR DESCRIPTION
- Ensure 3xx redirect exceptions do not get logged by creating a custom
  activation strategy for how the FingersCrossed log handler is fired.
  This may not be needed in the future as if
  https://github.com/symfony/symfony/pull/25533 is merged we would be
  able to do this with Symfony config rather than writing custom code.
- Ensure redirect exceptions don't have any body content (and thus
  don't make any calls to Orbit or Branding)

You will still see exception notices in dev for redirects because the
errors are only swallowed if you are using the FingersCrossed log
handler, which is only the case in production.

Fixes PROGRAMMES-5835