### PR TITLE
Remove deprecations by removing overrides for render() and redirect()

### DIFF
--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -191,33 +191,35 @@ abstract class BaseController extends AbstractController
     }
 
     /**
-     * Renders a view. Same as parent but using $this->response
-     *
-     * @param string        $view       The view name
-     * @param array         $parameters An array of parameters to pass to the view
-     * @param Response      $response   A response instance
-     *
-     * @return Response A Response instance
-     */
-    protected function render($view, array $parameters = [], Response $response = null): Response
-    {
-        return parent::render($view, $parameters, $response ?? $this->response);
-    }
-
-    /**
      * Returns a RedirectResponse to the given URL.
      * This picks up the default cache configuration of $this->response that was
-     * set in the constructor
+     * set in the constructor, unlike ->redirect()
      *
      * @param string $url    The URL to redirect to
      * @param int    $status The status code to use for the Response
      *
      * @return RedirectResponse
      */
-    protected function redirect($url, $status = 302): RedirectResponse
+    protected function cachedRedirect($url, $status = 302): RedirectResponse
     {
         $headers = $this->response->headers->all();
         return new RedirectResponse($url, $status, $headers);
+    }
+
+    /**
+     * Returns a RedirectResponse to the given route with the given parameters.
+     *  * This picks up the default cache configuration of $this->response that was
+     * set in the constructor, unlike ->redirect()
+     *
+     * @param string $route      The name of the route
+     * @param array  $parameters An array of parameters
+     * @param int    $status     The status code to use for the Response
+     *
+     * @return RedirectResponse
+     */
+    protected function cachedRedirectToRoute($route, array $parameters = array(), $status = 302): RedirectResponse
+    {
+        return $this->cachedRedirect($this->generateUrl($route, $parameters), $status);
     }
 
     /**

--- a/src/Controller/FindByPid/VersionController.php
+++ b/src/Controller/FindByPid/VersionController.php
@@ -15,6 +15,6 @@ class VersionController extends BaseController
     public function __invoke(Version $version)
     {
         $episodePid = (string) $version->getProgrammeItem()->getPid();
-        return $this->redirectToRoute('find_by_pid', ['pid' => $episodePid], 303);
+        return $this->cachedRedirectToRoute('find_by_pid', ['pid' => $episodePid], 303);
     }
 }

--- a/src/Controller/Partial/RecipesController.php
+++ b/src/Controller/Partial/RecipesController.php
@@ -5,13 +5,11 @@ namespace App\Controller\Partial;
 
 use App\Controller\BaseController;
 use App\ExternalApi\Recipes\Service\RecipesService;
-use Symfony\Component\HttpFoundation\Request;
 
 class RecipesController extends BaseController
 {
     public function __invoke(
         RecipesService $recipesService,
-        Request $request,
         string $pid
     ) {
         $apiResponse = $recipesService->fetchRecipesByPid($pid)->wait(true);
@@ -33,11 +31,12 @@ class RecipesController extends BaseController
         // Cache for 5 minutes
         $this->response()->setMaxAge(300);
 
+        // render does not automatically pick up the headers from the response
         return $this->render('partial/recipes.html.twig', [
             'recipes' => $apiResponse->getRecipes(),
             'total' => $apiResponse->getTotal(),
             'pid' => $pid,
             'showImage' => $showImage,
-        ]);
+        ], $this->response());
     }
 }

--- a/src/Controller/Partial/SchedulesOnNowController.php
+++ b/src/Controller/Partial/SchedulesOnNowController.php
@@ -44,7 +44,7 @@ class SchedulesOnNowController extends BaseController
 
         $designSystem = $request->query->get('partial');
         if (!in_array($designSystem, ['2013', 'legacy_2013', 'legacy_amen'])) {
-            return $this->redirectToRoute('find_by_pid', ['pid' => (string) $broadcast->getProgrammeItem()->getPid()]);
+            return $this->cachedRedirectToRoute('find_by_pid', ['pid' => (string) $broadcast->getProgrammeItem()->getPid()]);
         }
 
         $collapsedBroadcast = $collapsedBroadcastsService->findByBroadcast($broadcast);

--- a/src/Controller/SchedulesByNetworkUrlKeyController.php
+++ b/src/Controller/SchedulesByNetworkUrlKeyController.php
@@ -13,6 +13,6 @@ class SchedulesByNetworkUrlKeyController extends BaseController
             throw $this->createNotFoundException('Network not found');
         }
 
-        return $this->redirectToRoute('schedules_by_day', ['pid' => (string) $network->getDefaultService()->getPid()], 301);
+        return $this->cachedRedirectToRoute('schedules_by_day', ['pid' => (string) $network->getDefaultService()->getPid()], 301);
     }
 }

--- a/src/Controller/SchedulesVanityRedirectController.php
+++ b/src/Controller/SchedulesVanityRedirectController.php
@@ -24,7 +24,7 @@ class SchedulesVanityRedirectController extends BaseController
             }
 
             $params['date'] = $time->format('Y/m/d');
-            return $this->redirectToRoute('schedules_by_day', $params);
+            return $this->cachedRedirectToRoute('schedules_by_day', $params);
         }
 
         if (in_array($vanity, ['last_week', 'next_week', 'this_week'])) {
@@ -35,7 +35,7 @@ class SchedulesVanityRedirectController extends BaseController
             }
 
             $params['date'] = $time->format('o/\\wW');
-            return $this->redirectToRoute('schedules_by_week', $params);
+            return $this->cachedRedirectToRoute('schedules_by_week', $params);
         }
 
         if (in_array($vanity, ['last_month', 'next_month', 'this_month'])) {
@@ -46,7 +46,7 @@ class SchedulesVanityRedirectController extends BaseController
             }
 
             $params['date'] = $time->format('Y/m');
-            return $this->redirectToRoute('schedules_by_month', $params);
+            return $this->cachedRedirectToRoute('schedules_by_month', $params);
         }
 
         throw $this->createNotFoundException('Vanity URL ' . $vanity . ' not recognised');


### PR DESCRIPTION
These methods are marked @final in Symfony 3.4 so will trigger
deprecations if you try and override them in the BaseController. So
instead create alternative functions that shall pick up on the caching
headers.

Instead of render() use renderWithChrome() or renderWithoutChrome()
to ensure caching headers are set.

Instead of redirect() / redirectToRoute(), use cachedRedirect() and
cachedRedirectToRoute() to ensure caching headers are set.