### PR TITLE
Recommendations in ds2013

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -466,12 +466,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/bbc/programmes-pages-service.git",
-                "reference": "357468c4fcb54126f5bdd028007bfe6ae1d3dca7"
+                "reference": "df181e1be0e061966f5757fc0ee622cafc1a6b84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bbc/programmes-pages-service/zipball/357468c4fcb54126f5bdd028007bfe6ae1d3dca7",
-                "reference": "357468c4fcb54126f5bdd028007bfe6ae1d3dca7",
+                "url": "https://api.github.com/repos/bbc/programmes-pages-service/zipball/df181e1be0e061966f5757fc0ee622cafc1a6b84",
+                "reference": "df181e1be0e061966f5757fc0ee622cafc1a6b84",
                 "shasum": ""
             },
             "require": {
@@ -514,7 +514,7 @@
                 "source": "https://github.com/bbc/programmes-pages-service/tree/master",
                 "issues": "https://github.com/bbc/programmes-pages-service/issues"
             },
-            "time": "2018-01-30T10:48:35+00:00"
+            "time": "2018-01-31T11:59:49+00:00"
         },
         {
             "name": "behat/transliterator",

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -21,6 +21,11 @@ programme_episodes_player:
     defaults: { _controller: App\Controller\ProgrammeEpisodes\PlayerController }
     requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}' }
 
+programme_recommendations:
+    path: /programmes/{pid}/recommendations{extension}
+    defaults: { _controller: App\Controller\RecommendationsController, extension: '' }
+    requirements: { pid: '[0-9b-df-hj-np-tv-z]{8,15}', extension: '$|\.inc2013' }
+
 partial_programme_recipes:
     path: /programmes/{pid}/recipes.ameninc
     defaults: { _controller: App\Controller\Partial\RecipesController }

--- a/src/Controller/FindByPid/TlecController.php
+++ b/src/Controller/FindByPid/TlecController.php
@@ -109,13 +109,14 @@ class TlecController extends BaseController
             $relatedTopicsPromise = $adaClassService->findRelatedClassesByContainer($programme, $usePerContainerValues);
         }
 
-        $recommendationsPromise = $recEngService->getRecommendations(
-            $programme,
-            $onDemandEpisode,
-            $upcomingBroadcast ? $upcomingBroadcast->getProgrammeItem() : null,
-            $lastOn ? $lastOn->getProgrammeItem() : null,
-            2
-        );
+        $recommendationEpisode = $onDemandEpisode ?? ($upcomingBroadcast ? $upcomingBroadcast->getProgrammeItem() : null) ?? ($lastOn ? $lastOn->getProgrammeItem() : null);
+        $recommendationsPromise = new FulfilledPromise([]);
+        if ($recommendationEpisode) {
+            $recommendationsPromise = $recEngService->getRecommendations(
+                $recommendationEpisode,
+                2
+            );
+        }
 
         $favouritesButtonPromise = new FulfilledPromise(null);
         if ($programme->isRadio()) {

--- a/src/Controller/RecommendationsController.php
+++ b/src/Controller/RecommendationsController.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types = 1);
+namespace App\Controller;
+
+use App\Controller\BaseController;
+use App\ExternalApi\RecEng\Service\RecEngService;
+use BBC\ProgrammesPagesService\Domain\Entity\Programme;
+use BBC\ProgrammesPagesService\Domain\Entity\ProgrammeContainer;
+use BBC\ProgrammesPagesService\Domain\Entity\Clip;
+use BBC\ProgrammesPagesService\Domain\Entity\Episode;
+use BBC\ProgrammesPagesService\Service\ProgrammesAggregationService;
+use BBC\ProgrammesPagesService\Service\CollapsedBroadcastsService;
+use GuzzleHttp\Promise\FulfilledPromise;
+
+class RecommendationsController extends BaseController
+{
+    public function __invoke(
+        Programme $programme,
+        string $extension,
+        RecEngService $recEngService,
+        ProgrammesAggregationService $programmeAggregationService,
+        CollapsedBroadcastsService $collapsedBroadcastsService
+    ) {
+        $this->setContextAndPreloadBranding($programme);
+
+        // Show 10 items when rendering the main page, show 2 on includes
+        $limit = ($extension === '' ? 10 : 2);
+
+        $episode = $this->getEpisode(
+            $programme,
+            $programmeAggregationService,
+            $collapsedBroadcastsService
+        );
+
+        $promises = [
+            'recommendations' => new FulfilledPromise([]),
+        ];
+        if ($episode) {
+            $promises['recommendations'] = $recEngService->getRecommendations($episode, $limit);
+        }
+
+        if ($extension === '') {
+            // We haven't got around to rendering the main route yet,
+            // replace this with a call to $this->renderWithChrome later.
+            throw $this->createNotFoundException('No such page');
+        }
+
+        return $this->renderWithoutChrome(
+            'recommendations/show' . $extension . '.html.twig',
+            array_merge($this->resolvePromises($promises), [
+                'programme' => $programme,
+            ])
+        );
+    }
+
+    /**
+     * recEng requires an Episode pid, so this determines which to use based on the type of Programme passed into it
+     * Takes nullable args of latest, upcoming and last on episodes as this is called in TLEC controller and these are already fetched
+     */
+    private function getEpisode(
+        Programme $programme,
+        ProgrammesAggregationService $programmeAggregationService,
+        CollapsedBroadcastsService $collapsedBroadcastsService
+    ): ?Episode {
+        if ($programme instanceof Episode) {
+            return $programme;
+        }
+
+        if ($programme instanceof Clip) {
+            if ($programme->getParent() && $programme->getParent() instanceof Episode) {
+                return $programme->getParent();
+            }
+        }
+
+        if ($programme instanceof ProgrammeContainer && $programme->getAggregatedEpisodesCount()) {
+            if ($programme->getAvailableEpisodesCount()) {
+                $onDemandEpisodes = $programmeAggregationService->findStreamableOnDemandEpisodes($programme, 1);
+                if ($onDemandEpisodes) {
+                    return $onDemandEpisodes[0];
+                }
+            }
+
+            $upcomingBroadcast = $collapsedBroadcastsService->findNextDebutOrRepeatOnByProgramme($programme);
+            if ($upcomingBroadcast) {
+                return $upcomingBroadcast[0]->getProgrammeItem();
+            }
+
+            $lastOnBroadcast = $collapsedBroadcastsService->findPastByProgramme($programme, 1);
+            if ($lastOnBroadcast) {
+                return $lastOnBroadcast[0]->getProgrammeItem();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Ds2013/Css/Components/_icon-box.scss
+++ b/src/Ds2013/Css/Components/_icon-box.scss
@@ -1,0 +1,76 @@
+.icon-box {
+    display: block;
+    margin-bottom: $basic-spacing;
+}
+
+.icon-box--flush {
+    margin-bottom: 0;
+}
+
+// Must be nested in order to have higher specificity than the page links
+.icon-box .icon-box__link {
+    min-height: 144px;
+    padding: $wide-spacing;
+    display: block;
+    position: relative;
+
+    &:hover,
+    &:active,
+    &:focus {
+        text-decoration: none;
+    }
+}
+
+.icon-box__icon {
+    position: absolute;
+    bottom: $wide-spacing;
+    left: $wide-spacing;
+    width: 32px;
+    height: 32px;
+}
+
+.icon-box__hgroup,
+.icon-box__title,
+.icon-box__subtitle {
+    display: block;
+}
+
+.icon-box__hgroup {
+    padding-bottom: 40px;
+}
+
+.icon-box__title {
+    margin: 0;
+    padding: 0;
+}
+
+.icon-box__subtitle {
+    opacity: 0.8;
+    margin: $basic-half-spacing 0 0;
+    padding: 0;
+    font-weight: normal;
+}
+
+.icon-box__note {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    margin: 0 $wide-spacing $wide-spacing 0;
+    padding-left: 56px;
+    text-align: right;
+}
+
+.icon-box__notedetail {
+    opacity: 0.8;
+}
+
+
+@include mq-range('bpw') {
+    .icon-box {
+        margin-bottom: $wide-spacing;
+    }
+
+    .icon-box--flush {
+        margin-bottom: 0;
+    }
+}

--- a/src/Ds2013/PresenterFactory.php
+++ b/src/Ds2013/PresenterFactory.php
@@ -182,11 +182,10 @@ class PresenterFactory
 
     /**
      * @param Programme $programme
-     * @param Programme[] $recommendations
      * @param array $options
      */
-    public function footerPresenter(Programme $programme, array $recommendations, array $options = []): FooterPresenter
+    public function footerPresenter(Programme $programme, array $options = []): FooterPresenter
     {
-        return new FooterPresenter($programme, $recommendations, $options);
+        return new FooterPresenter($programme, $options);
     }
 }

--- a/src/Ds2013/Presenters/Domain/Programme/_programme.scss
+++ b/src/Ds2013/Presenters/Domain/Programme/_programme.scss
@@ -344,10 +344,10 @@ $programme-icon-bpw-size: gel-typography('bpw', 'delta', 'font-size') + 4px;
 // Per breakpoint toggles for programme image top or left.
 // We need to overwrite each property to ensure that no phantom properties from
 // the other declaration remain.
-@mixin programme-image-setup($namespace: '', $spacing: $basic-spacing) {
+@mixin programme-image-setup($suffix: '', $spacing: $basic-spacing) {
     $half-spacing: $spacing / 2;
 
-    .#{$namespace}programme--list {
+    .programme--list#{$suffix} {
         .programme__img {
             float: left;
             margin-right: $spacing;
@@ -367,8 +367,8 @@ $programme-icon-bpw-size: gel-typography('bpw', 'delta', 'font-size') + 4px;
         }
     }
 
-    .#{$namespace}programme--list-featured {
-        @extend .#{$namespace}programme--list;
+    .programme--list-featured#{$suffix} {
+        @extend .programme--list#{$suffix};
 
         .programme__body {
             margin-top: $spacing;
@@ -390,7 +390,7 @@ $programme-icon-bpw-size: gel-typography('bpw', 'delta', 'font-size') + 4px;
         }
     }
 
-    .#{$namespace}programme--grid {
+    .programme--grid#{$suffix} {
         .programme__img {
             float: none;
             margin-right: 0;
@@ -442,6 +442,6 @@ $programme-icon-bpw-size: gel-typography('bpw', 'delta', 'font-size') + 4px;
     $spacing: if(index(('bpb1', 'bpb2'), $name), $basic-spacing, $wide-spacing);
 
     @include mq-range($name) {
-        @include programme-image-setup('#{$name}-', $spacing);
+        @include programme-image-setup('\\@#{$name}', $spacing);
     }
 }

--- a/src/Ds2013/Presenters/Section/Footer/FooterPresenter.php
+++ b/src/Ds2013/Presenters/Section/Footer/FooterPresenter.php
@@ -17,15 +17,11 @@ class FooterPresenter extends Presenter
     /** @var Network */
     private $network;
 
-    /** @var Programme[] */
-    private $recommendations;
-
-    public function __construct(Programme $programme, array $recommendations, array $options = [])
+    public function __construct(Programme $programme, array $options = [])
     {
         parent::__construct($options);
 
         $this->programme = $programme;
-        $this->recommendations = $recommendations;
         $this->network = $programme->getNetwork();
     }
 
@@ -97,14 +93,6 @@ class FooterPresenter extends Presenter
     public function getPid(): string
     {
         return (string) $this->programme->getPid();
-    }
-
-    /**
-     * @return Programme[]
-     */
-    public function getRecommendations(): array
-    {
-        return $this->recommendations;
     }
 
     public function isWorldNews(): bool

--- a/src/Ds2013/Presenters/Section/Footer/footer.html.twig
+++ b/src/Ds2013/Presenters/Section/Footer/footer.html.twig
@@ -3,7 +3,21 @@
         <div class="grid grid--flush 1/2@bpw 5/12@bpw2 5/12@bpe"><div class="b-g-p">
             <!-- (Recommendations) You may also like -->
             {%- if not footer.isWorldNews() -%}
-                {# TODO render recomendations #}
+                <div class="icon-box br-box-page lazy-module"
+                    data-lazyload-inc="{{ path('programme_recommendations', {pid: footer.getPid(), extension: '.inc2013'}) }}"
+                    data-lazyload-threshold="320"
+                    data-lazyload-delay="true"
+                >
+                    <a class="icon-box__link br-box-page__link br-page-link-onbg015 br-page-linkhover-onbg015--hover" href="{{ path('programme_recommendations', {pid: footer.getPid()}) }}">
+                        {{ gelicon('basics', 'recommend', 'icon-box__icon br-pseudolink') }}
+
+                        <div class="icon-box__hgroup">
+                            <h3 class="icon-box__title gamma">{{ tr('you_might_also_like') }}</h3>
+                        </div>
+
+                        <p class="icon-box__note micro">{{ tr('view_all') }}</p>
+                    </a>
+                </div>
             {%- endif -%}
         </div></div>
         <div class="grid grid--flush 1/2@bpw 1/4@bpw2 1/3@bpe">

--- a/src/Ds2013/Presenters/Utilities/_lazyload.scss
+++ b/src/Ds2013/Presenters/Utilities/_lazyload.scss
@@ -5,7 +5,7 @@
 
     &.lazy-module--loading::after {
         content: '';
-        background: url('../img/icons/loading.gif') center center no-repeat;
+        background: image-url('loading.gif') center center no-repeat;
         background-color: rgba(0, 0, 0, 0.5);
         position: absolute;
         top: 0;

--- a/src/Ds2013/_ds2013-components.scss
+++ b/src/Ds2013/_ds2013-components.scss
@@ -57,7 +57,7 @@
 @import 'Presenters/Domain/Programme/programme';
 
 @import 'Presenters/Utilities/DateList/date-list';
-// @import 'objects/icon-box';
+@import 'Css/Components/icon-box';
 // @import 'objects/iplayer-icon';
 // @import 'objects/letters';
 // @import 'objects/pagination';

--- a/src/ExternalApi/RecEng/Service/RecEngStubService.php
+++ b/src/ExternalApi/RecEng/Service/RecEngStubService.php
@@ -3,7 +3,6 @@
 namespace App\ExternalApi\RecEng\Service;
 
 use BBC\ProgrammesPagesService\Domain\Entity\Episode;
-use BBC\ProgrammesPagesService\Domain\Entity\Programme;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 
@@ -11,10 +10,7 @@ class RecEngStubService extends RecEngService
 {
     /** For use in controller unit tests */
     public function getRecommendations(
-        Programme $programme,
-        ?Episode $latestEpisode,
-        ?Episode $upcomingEpisode,
-        ?Episode $lastOnEpisode,
+        Episode $episode,
         int $limit = 2
     ): PromiseInterface {
         return new FulfilledPromise([]);

--- a/templates/base_ds2013.html.twig
+++ b/templates/base_ds2013.html.twig
@@ -91,7 +91,7 @@
         <div class="{% block page_classes %}programmes-page text-base b-g-p{% endblock %}" id="programmes-content" role="main">
         {% block body %}{% endblock %}
         </div>
-        {% if programme is defined %}{{ ds2013('footer', programme, recommendations ?? []) }}{% endif %}
+        {% if programme is defined %}{{ ds2013('footer', programme) }}{% endif %}
         {{ gelicons_source() }}
         <script>
             require(['rv-bootstrap']);

--- a/templates/recommendations/show.inc2013.html.twig
+++ b/templates/recommendations/show.inc2013.html.twig
@@ -1,0 +1,29 @@
+{% extends 'base_ds2013_partial.html.twig' %}
+
+{%- block body -%}
+    {%- if recommendations -%}
+        <div class="footer__recommendations br-keyline">
+        <h2>{{ tr('you_might_also_like') }}</h2>
+        <ol id="recommendations" class="grid-wrapper">
+            {%- for prog in recommendations -%}
+                <li class="grid 1/2">
+                {{- ds2013('programme', prog, {
+                    context_programme: programme,
+                    highlight_box_classes: 'br-box-subtle highlight-box--list-borderless programme--grid@bpb1 highlight-box--grid@bpb1 programme--grid@bpw highlight-box--grid@bpw',
+                    body_options: {
+                        show_synopsis: false,
+                        show_duration: false,
+                    },
+                    image_options: {
+                        classes: '1/1@bpb1 1/1@bpw',
+                        default_width: 148,
+                        sizes: { 0: 0, 320: 1/2, 600: 1/4, 770: 5/24, 1008: '178px'},
+                        is_lazy_loaded: false,
+                    },
+                }) -}}
+                </li>
+            {%- endfor -%}
+        </ol>
+        </div>
+    {%- endif -%}
+{%- endblock -%}

--- a/tests/Ds2013/Presenters/Section/Footer/FooterPresenterTest.php
+++ b/tests/Ds2013/Presenters/Section/Footer/FooterPresenterTest.php
@@ -39,7 +39,7 @@ class FooterPresenterTest extends TestCase
 
     public function testRetrieveNetworkData()
     {
-        $footerPresenter = new FooterPresenter($this->mockProgramme, []);
+        $footerPresenter = new FooterPresenter($this->mockProgramme);
 
         $this->assertEquals('BBC One', $footerPresenter->getNetworkName());
         $this->assertEquals('bbcone', $footerPresenter->getNetworkUrlKey());
@@ -56,7 +56,7 @@ class FooterPresenterTest extends TestCase
 
         $this->mockProgramme->method('getGenres')->willReturn([$genre, $someOtherGenre]);
 
-        $footerPresenter = new FooterPresenter($this->mockProgramme, []);
+        $footerPresenter = new FooterPresenter($this->mockProgramme);
         $this->assertEquals([$someOtherGenre, $genre], $footerPresenter->getGenres());
     }
 
@@ -67,7 +67,7 @@ class FooterPresenterTest extends TestCase
 
         $this->mockProgramme->method('getFormats')->willReturn([$format, $otherFormat]);
 
-        $footerPresenter = new FooterPresenter($this->mockProgramme, []);
+        $footerPresenter = new FooterPresenter($this->mockProgramme);
         $this->assertEquals([$format, $otherFormat], $footerPresenter->getFormats());
     }
 
@@ -81,7 +81,7 @@ class FooterPresenterTest extends TestCase
             'getNetwork' => $mockWorldNewsNetwork,
         ]);
 
-        $footerPresenter = new FooterPresenter($mockWorldProgramme, []);
+        $footerPresenter = new FooterPresenter($mockWorldProgramme);
         $this->assertEquals(true, $footerPresenter->isWorldNews());
     }
 }

--- a/tests/ExternalApi/RecEng/Service/RecEngServiceTest.php
+++ b/tests/ExternalApi/RecEng/Service/RecEngServiceTest.php
@@ -50,7 +50,7 @@ class RecEngServiceTest extends BaseServiceTestCase
             ->with([new Pid('p04vjd23'), new Pid('p0576pm5')])
             ->willReturn($programmesServiceResult);
 
-        $result = $service->getRecommendations($mockEpisode, null, null, null, 2)->wait(true);
+        $result = $service->getRecommendations($mockEpisode, 2)->wait(true);
 
         $this->assertContainsOnlyInstancesOf(Programme::class, $result);
         $this->assertContains('p04vjd23', [$result[0]->getPid(), $result[1]->getPid()]);
@@ -71,7 +71,7 @@ class RecEngServiceTest extends BaseServiceTestCase
 
         $this->mockProgrammesService->method('findByPids')->willReturn([$this->createMock(Programme::class)]);
 
-        $result = $service->getRecommendations($mockEpisode, null, null, null, 2)->wait(true);
+        $result = $service->getRecommendations($mockEpisode, 2)->wait(true);
 
         $requestQueryString = $this->getLastRequestUrl($history);
         $this->assertContains($expectedKey, $requestQueryString);
@@ -104,7 +104,7 @@ class RecEngServiceTest extends BaseServiceTestCase
             ->with([new Pid('p04vjd23')])
             ->willReturn($programmesServiceResult);
 
-        $result = $service->getRecommendations($mockEpisode, null, null, null, 1)->wait(true);
+        $result = $service->getRecommendations($mockEpisode, 1)->wait(true);
 
         $this->assertContainsOnlyInstancesOf(Programme::class, $result);
         $this->assertContains('p04vjd23', [$result[0]->getPid()]);
@@ -119,7 +119,7 @@ class RecEngServiceTest extends BaseServiceTestCase
         $mockEpisode = $this->createMock(Episode::class);
         $this->mockProgrammesService->method('findByPids')->willReturn([]);
 
-        $result = $service->getRecommendations($mockEpisode, null, null, null, 2)->wait(true);
+        $result = $service->getRecommendations($mockEpisode, 2)->wait(true);
 
         $this->assertEquals([], $result);
     }
@@ -133,7 +133,7 @@ class RecEngServiceTest extends BaseServiceTestCase
         $mockEpisode = $this->createMock(Episode::class);
         $this->mockProgrammesService->method('findByPids')->willReturn([]);
 
-        $result = $service->getRecommendations($mockEpisode, null, null, null, 2)->wait(true);
+        $result = $service->getRecommendations($mockEpisode, 2)->wait(true);
 
         $this->assertEquals([], $result);
     }
@@ -146,7 +146,7 @@ class RecEngServiceTest extends BaseServiceTestCase
         );
 
         $mockEpisode = $this->createMock(Episode::class);
-        $result = $service->getRecommendations($mockEpisode, null, null, null, 2)->wait(true);
+        $result = $service->getRecommendations($mockEpisode, 2)->wait(true);
 
         $this->assertEquals([], $result);
     }
@@ -158,7 +158,7 @@ class RecEngServiceTest extends BaseServiceTestCase
         );
 
         $mockEpisode = $this->createMock(Episode::class);
-        $result = $service->getRecommendations($mockEpisode, null, null, null, 2)->wait(true);
+        $result = $service->getRecommendations($mockEpisode, 2)->wait(true);
 
         $this->assertEquals([], $result);
     }


### PR DESCRIPTION
Lazy load recommendations into the ds2013 footer.

Simplify RecEng service signature to only accept Episodes. All the logic for picking what episode should be passed into it should be done in the RecommendationsController. (i.e. if you passed in a container, use the latest available ondemand episode, else the next on broadcast, else try the last on broadcast). Currently that logic is duplicated in the TlecController but I think we should seek to make amen pages use a lazy loaded partial for recommendations at some point in the future.

Read the commit messages for more info.

Currently the ordering of recommendations is wrong on some pages (e.g. b006v5y2), this is because calling findByPids doesn't guarantee returning results in the same order as the order of pids you specified. https://github.com/bbc/programmes-pages-service/pull/227 fixes that