### PR TITLE
Don't use last/next broadcast episode when looking for recommendations

### DIFF
--- a/src/Controller/FindByPid/TlecController.php
+++ b/src/Controller/FindByPid/TlecController.php
@@ -109,11 +109,10 @@ class TlecController extends BaseController
             $relatedTopicsPromise = $adaClassService->findRelatedClassesByContainer($programme, $usePerContainerValues);
         }
 
-        $recommendationEpisode = $onDemandEpisode ?? ($upcomingBroadcast ? $upcomingBroadcast->getProgrammeItem() : null) ?? ($lastOn ? $lastOn->getProgrammeItem() : null);
         $recommendationsPromise = new FulfilledPromise([]);
-        if ($recommendationEpisode) {
+        if ($onDemandEpisode) {
             $recommendationsPromise = $recEngService->getRecommendations(
-                $recommendationEpisode,
+                $onDemandEpisode,
                 2
             );
         }

--- a/src/ExternalApi/RecEng/Service/RecEngService.php
+++ b/src/ExternalApi/RecEng/Service/RecEngService.php
@@ -57,6 +57,8 @@ class RecEngService
      * Returns a promise of an array of Programme objects which are fetched based on RecEng results
      * Will return an empty array if not results were found or RecEng cannot be reached
      *
+     * RecEng shall only return results if the Episode passed is available to stream
+     *
      * @param Episode $episode
      * @param int $limit
      * @return PromiseInterface (returns Programme[] when unwrapped)


### PR DESCRIPTION
Simplify and speed up recommendations by only looking for the streamable
episodes. As far as I can tell RecEng only returns results when you give
it a streamable episode.

For example:
Doctor who has no available episodes and no recommendations - I'm sure this had recommendations a few days ago when the Christmas special was still available.
Strictly has no available episodes and no recommendations
Weakest Link has one available episode and has recommendations. When passing the available episode into RecEng there are episodes, if you pass any of its sibling episodes into RecEng you get no results.