### PR TITLE
Remove invisible social bar text

### DIFF
--- a/src/DsAmen/Presenters/Section/Map/SubPresenter/social_bar.html.twig
+++ b/src/DsAmen/Presenters/Section/Map/SubPresenter/social_bar.html.twig
@@ -7,7 +7,6 @@
                     <li class="map-social__icon br-secondary-link-onbg015--hover">
                         <a href="{{ details.getValue() }}" title="{{ details.getType()|capitalize }}" data-extlinktrack="socialbar_{{ details.getType() }}">
                             {{ gelicon('social', details.getType(), 'gelicon--programme') }}
-                            <span class="invisible">{{ details.getType() }}</span>
                         </a>
                     </li>
                 {%- endfor -%}


### PR DESCRIPTION
Because the type appears in both the title on the <a> tag and in
invisible text it is read out twice by screen readers. Once is
sufficient. The title has more value to sighted users, as you can
mouseover items see what they are if you are unfamilar with the logos so
keep that.

Fixes PROGRAMMES-6180