### PR TITLE
Remove usage of countStreamableOnDemandEpisodes query

### DIFF
--- a/src/Controller/ProgrammeEpisodes/GuideController.php
+++ b/src/Controller/ProgrammeEpisodes/GuideController.php
@@ -8,7 +8,6 @@ use App\Ds2013\Presenters\Utilities\Paginator\PaginatorPresenter;
 use BBC\ProgrammesCachingLibrary\CacheInterface;
 use BBC\ProgrammesPagesService\Domain\Entity\ProgrammeContainer;
 use BBC\ProgrammesPagesService\Service\CollapsedBroadcastsService;
-use BBC\ProgrammesPagesService\Service\ProgrammesAggregationService;
 use BBC\ProgrammesPagesService\Service\ProgrammesService;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -20,7 +19,6 @@ class GuideController extends BaseController
         ProgrammeContainer $programme,
         PresenterFactory $presenterFactory,
         ProgrammesService $programmesService,
-        ProgrammesAggregationService $programmeAggregationService,
         CollapsedBroadcastsService $collapsedBroadcastService,
         Request $request
     ) {
@@ -53,13 +51,12 @@ class GuideController extends BaseController
         }
 
         $upcomingBroadcastCount = $collapsedBroadcastService->countUpcomingByProgramme($programme, CacheInterface::MEDIUM);
-        $totalAvailableEpisodes = $programmeAggregationService->countStreamableOnDemandEpisodes($programme);
 
         $subNavPresenter = $presenterFactory->episodesSubNavPresenter(
             $this->request()->attributes->get('_route'),
             $programme->getNetwork() === null || !$programme->getNetwork()->isInternational(),
             $programme->getFirstBroadcastDate() !== null,
-            $totalAvailableEpisodes,
+            $programme->getAvailableEpisodesCount(),
             $programme->getPid(),
             $upcomingBroadcastCount
         );

--- a/src/Controller/ProgrammeEpisodes/GuidePartialController.php
+++ b/src/Controller/ProgrammeEpisodes/GuidePartialController.php
@@ -5,7 +5,6 @@ namespace App\Controller\ProgrammeEpisodes;
 use App\Ds2013\PresenterFactory;
 use BBC\ProgrammesPagesService\Domain\Entity\ProgrammeContainer;
 use BBC\ProgrammesPagesService\Service\CollapsedBroadcastsService;
-use BBC\ProgrammesPagesService\Service\ProgrammesAggregationService;
 use BBC\ProgrammesPagesService\Service\ProgrammesService;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -15,7 +14,6 @@ class GuidePartialController extends GuideController
         ProgrammeContainer $programme,
         PresenterFactory $presenterFactory,
         ProgrammesService $programmesService,
-        ProgrammesAggregationService $programmeAggregationService,
         CollapsedBroadcastsService $collapsedBroadcastService,
         Request $request
     ) {

--- a/src/Controller/ProgrammeEpisodes/PlayerController.php
+++ b/src/Controller/ProgrammeEpisodes/PlayerController.php
@@ -38,17 +38,17 @@ class PlayerController extends BaseController
         }
 
         $upcomingBroadcastCount = $collapsedBroadcastService->countUpcomingByProgramme($programme, CacheInterface::MEDIUM);
-        $totalAvailableEpisodes = $programmeAggregationService->countStreamableOnDemandEpisodes($programme);
+        $availableEpisodesCount = $programme->getAvailableEpisodesCount();
 
         $paginator = null;
-        if ($totalAvailableEpisodes > $limit) {
-            $paginator = new PaginatorPresenter($page, $limit, $totalAvailableEpisodes);
+        if ($availableEpisodesCount > $limit) {
+            $paginator = new PaginatorPresenter($page, $limit, $availableEpisodesCount);
         }
 
         $this->setIstatsExtraLabels(
             [
-                'has_available_items' => count($totalAvailableEpisodes) > 0 ? 'true' : 'false',
-                'total_available_episodes' => (string) $totalAvailableEpisodes,
+                'has_available_items' => $availableEpisodesCount > 0 ? 'true' : 'false',
+                'total_available_episodes' => (string) $availableEpisodesCount,
             ]
         );
 
@@ -56,7 +56,7 @@ class PlayerController extends BaseController
             $this->request()->attributes->get('_route'),
             $programme->getNetwork() === null || !$programme->getNetwork()->isInternational(),
             $programme->getFirstBroadcastDate() !== null,
-            $totalAvailableEpisodes,
+            $availableEpisodesCount,
             $programme->getPid(),
             $upcomingBroadcastCount
         );


### PR DESCRIPTION
This value is denormalised onto ProgrammeContainers and Episodes already
so we don't need to make this query.