### PR TITLE
Related links

### DIFF
--- a/src/Controller/FindByPid/EpisodeController.php
+++ b/src/Controller/FindByPid/EpisodeController.php
@@ -7,6 +7,7 @@ use BBC\ProgrammesPagesService\Domain\Entity\Episode;
 use BBC\ProgrammesPagesService\Service\ContributionsService;
 use BBC\ProgrammesPagesService\Service\ProgrammesAggregationService;
 use BBC\ProgrammesPagesService\Service\PromotionsService;
+use BBC\ProgrammesPagesService\Service\RelatedLinksService;
 
 class EpisodeController extends BaseController
 {
@@ -14,7 +15,8 @@ class EpisodeController extends BaseController
         Episode $episode,
         ContributionsService $contributionsService,
         ProgrammesAggregationService $aggregationService,
-        PromotionsService $promotionsService
+        PromotionsService $promotionsService,
+        RelatedLinksService $relatedLinksService
     ) {
         $this->setIstatsProgsPageType('programmes_episode');
         $this->setContextAndPreloadBranding($episode);
@@ -29,6 +31,11 @@ class EpisodeController extends BaseController
             $contributions = $contributionsService->findByContributionToProgramme($episode);
         }
 
+        $relatedLinks = [];
+        if ($episode->getRelatedLinksCount() > 0) {
+            $relatedLinks = $relatedLinksService->findByRelatedToProgramme($episode, ['related_site', 'miscellaneous']);
+        }
+
         // TODO check $episode->getPromotionsCount() once it is populated in
         // Faucet to potentially save on a DB query
         $promotions = $promotionsService->findActivePromotionsByEntityGroupedByType($episode);
@@ -37,6 +44,7 @@ class EpisodeController extends BaseController
             'contributions' => $contributions,
             'programme' => $episode,
             'clips' => $clips,
+            'relatedLinks' => $relatedLinks,
             'promotions' => $promotions,
         ]);
     }

--- a/templates/find_by_pid/_related_links_module.html.twig
+++ b/templates/find_by_pid/_related_links_module.html.twig
@@ -1,0 +1,15 @@
+<div class="component component--box component--box--striped component--box--secondary">
+    <div class="component__header br-box-highlight">
+        <h2>{{ tr('related_links') }}</h2>
+    </div>
+    <div class="component__body br-box-subtle">
+        <ul class="no-margin-vertical list-spaced">
+            {%- for link in relatedLinks -%}
+                <li>
+                    <a href="{{ link.getUri() }}">{{ link.getTitle() }}</a>
+                    {%- if link.isExternal() %} <span class="milli">({{ link.getHost() }})</span>{% endif -%}
+                </li>
+            {%- endfor -%}
+        </ul>
+    </div>
+</div>

--- a/templates/find_by_pid/episode.html.twig
+++ b/templates/find_by_pid/episode.html.twig
@@ -120,21 +120,10 @@
                 {# TODO Vote module #}
 
                 {% if relatedLinks %}
-                    <div class="component component--box component--box--striped component--box--secondary">
-                        <div class="component__header br-box-highlight">
-                            <h2>{{ tr('related_links') }}</h2>
-                        </div>
-                        <div class="component__body br-box-subtle">
-                            <ul class="no-margin-vertical list-spaced">
-                                {%- for link in relatedLinks -%}
-                                    <li>
-                                        <a href="{{ link.getUri() }}">{{ link.getTitle() }}</a>
-                                        {%- if link.isExternal() %} <span class="milli">({{ link.getHost() }})</span>{% endif -%}
-                                    </li>
-                                {%- endfor -%}
-                            </ul>
-                        </div>
-                    </div>
+                    {% include 'find_by_pid/_related_links_module.html.twig' with {
+                        'programme': programme,
+                        'relatedLinks': relatedLinks,
+                    } only %}
                 {% endif %}
             </div>
         </div>

--- a/templates/find_by_pid/episode.html.twig
+++ b/templates/find_by_pid/episode.html.twig
@@ -119,7 +119,23 @@
 
                 {# TODO Vote module #}
 
-                {# TODO Related Links module #}
+                {% if relatedLinks %}
+                    <div class="component component--box component--box--striped component--box--secondary">
+                        <div class="component__header br-box-highlight">
+                            <h2>{{ tr('related_links') }}</h2>
+                        </div>
+                        <div class="component__body br-box-subtle">
+                            <ul class="no-margin-vertical list-spaced">
+                                {%- for link in relatedLinks -%}
+                                    <li>
+                                        <a href="{{ link.getUri() }}">{{ link.getTitle() }}</a>
+                                        {%- if link.isExternal() %} <span class="milli">({{ link.getHost() }})</span>{% endif -%}
+                                    </li>
+                                {%- endfor -%}
+                            </ul>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Adding the related links module to the episode page.

---

I'm slightly torn on the 2nd commit - moving this into a partial rather than inlined into the page. This and several other modules (e.g. list of clips, list of galleries) are present on the episode, clip and series page in the same format so it makes sense to deduplicate them IMO. Do you agree?

However I'm not sure what the future state of the Series page is - in the old world before the TV Brand Page it was almost identical to the Series page (in v2 there was just 'container' that encompassed both page types), so recreating the old series page would probably be more work compared to basing it on the new Amen-based brand page. Would it be feasible to get a new design for that page?