### PR TITLE
Bugfixes for clips list

### DIFF
--- a/templates/find_by_pid/episode.html.twig
+++ b/templates/find_by_pid/episode.html.twig
@@ -47,9 +47,9 @@
                                 <h2>{{ tr('clips', programme.getAvailableClipsCount()) }}</h2>
                             </div>
                             <div class="component__body">
-                                <ul class="grid-wrapper highlight-box-wrapper highlight-box-wrapper--grid@bpb1 bpw-highlight-box-wrapper--grid">
+                                <ul class="grid-wrapper highlight-box-wrapper highlight-box-wrapper--grid@bpb1 highlight-box-wrapper--grid@bpw">
                                     {% for clip in clips %}
-                                        <li class="grid 1/2@bpb1 1/2@bpw">
+                                        <li class="grid{{ clips|length > 1 ? ' 1/2@bpb1 1/2@bpw' }}">
                                             {{ ds2013('programme', clip, {
                                                 'context_programme': programme,
                                                 'highlight_box_classes':'highlight-box--list highlight-box--grid@bpb1 programme--grid@bpb1 highlight-box--grid@bpw programme--grid@bpw',
@@ -68,12 +68,14 @@
                                     {% endfor %}
                                 </ul>
                             </div>
-                            <div class="component__footer br-box-subtle">
-                                <a class="component__footer__link" href="{{ path('programme_clips', { pid: programme.getPid() }) }}">
-                                    <span class="component__footer__title">{{ tr('see_all_clips_from', {'%1': programme.getTitle()}) }}</span>
-                                    <span class="component__footer__detail">({{ programme.getAvailableClipsCount() }})</span>
-                                </a>
-                            </div>
+                            {% if programme.getAvailableClipsCount() > 1 %}
+                                <div class="component__footer br-box-subtle">
+                                    <a class="component__footer__link" href="{{ path('programme_clips', { pid: programme.getPid() }) }}">
+                                        <span class="component__footer__title">{{ tr('see_all_clips_from', {'%1': programme.getTitle()}) }}</span>
+                                        <span class="component__footer__detail">({{ programme.getAvailableClipsCount() }})</span>
+                                    </a>
+                                </div>
+                            {% endif %}
                         </div>
                     {% endif %}
 


### PR DESCRIPTION
* Use new style per-breakpoint class
* When there is only one clip make it full width to avoid whitespace
* When there is only one clip hide the component footer

---

FAO @votemike as I think he did the the original clip list work

Example page to demo a single clip: http://www.bbc.co.uk/programmes/b01jxym4