### PR TITLE
Support bounded images in the ImagePresenter

### DIFF
--- a/src/DsShared/Utilities/Image/ImagePresenter.php
+++ b/src/DsShared/Utilities/Image/ImagePresenter.php
@@ -14,6 +14,7 @@ class ImagePresenter extends Presenter
         'is_lazy_loaded' => true,
         'srcsets' => [80, 160, 320, 480, 640, 768, 896, 1008],
         'ratio' => (16 / 9),
+        'is_bounded' => false,
         'alt' => '',
     ];
 
@@ -137,8 +138,20 @@ class ImagePresenter extends Presenter
 
     private function buildSrcUrl(?int $width): string
     {
-        if ($this->getOption('ratio')) {
-            $height = (int) round($width / $this->getOption('ratio'));
+        // Bounded images force a specific ratio image by adding borders to
+        // the shorter dimension, rather than cutting off part of the image.
+        // Bounded imagechef recipes are only defined for recipes with an
+        // explicit ratio. For instance 320x320_b and 320x180_b are valid, but
+        // 320xn is not. Which makes sense as images without an explicit
+        // height do not get forced to a particular ratio at all.
+
+        $ratio = $this->getOption('ratio');
+        if ($ratio) {
+            $height = (string) round($width / $ratio, 0);
+            if ($this->getOption('is_bounded')) {
+                $height .= '_b';
+            }
+
             return $this->image->getUrl((string) $width, $height);
         }
 

--- a/tests/DsShared/Utilities/Image/ImagePresenterTest.php
+++ b/tests/DsShared/Utilities/Image/ImagePresenterTest.php
@@ -19,6 +19,7 @@ class ImagePresenterTest extends TestCase
         $this->assertEquals([80, 160, 320, 480, 640, 768, 896, 1008], $imagePresenter->getOption('srcsets'));
         $this->assertEquals('', $imagePresenter->getOption('alt'));
         $this->assertEquals((16 / 9), $imagePresenter->getOption('ratio'));
+        $this->assertEquals(false, $imagePresenter->getOption('is_bounded'));
 
         // Test generating src url using the defaultWidth argument
         $this->assertEquals('48 by 27', $imagePresenter->getSrc());
@@ -33,11 +34,12 @@ class ImagePresenterTest extends TestCase
             'srcsets' => [320],
             'alt' => 'alt text',
             'ratio' => 1/2,
+            'is_bounded' => true,
         ]);
 
         $this->assertEquals('(min-width: 8.125em) 50vw, 100vw', $imagePresenter->getSizes());
-        $this->assertEquals('300 by 600', $imagePresenter->getSrc());
-        $this->assertEquals('320 by 640 320w', $imagePresenter->getSrcsets());
+        $this->assertEquals('300 by 600_b', $imagePresenter->getSrc());
+        $this->assertEquals('320 by 640_b 320w', $imagePresenter->getSrcsets());
     }
 
     public function testSizesStringOverride(): void


### PR DESCRIPTION
This allows you to create an image recipe like '16x9_b'.

---

See https://confluence.dev.bbc.co.uk/display/programmes/Images+User+Guide for what the bounded images do