### PR TITLE
Fix a bug where a promotions content block has no layout parameter. T…

### DIFF
--- a/src/ExternalApi/Isite/Mapper/ContentBlockMapper.php
+++ b/src/ExternalApi/Isite/Mapper/ContentBlockMapper.php
@@ -257,7 +257,7 @@ class ContentBlockMapper extends Mapper
             case 'promotions':
                 $contentBlockData = $form->content;
                 $title = $this->getString($contentBlockData->title);
-                $layout = $this->getString($contentBlockData->layout);
+                $layout = $this->getString($contentBlockData->layout) ?: 'list'; // Default to list if unset
                 $promotions = [];
                 foreach ($contentBlockData->promotions as $promotion) {
                     // @codingStandardsIgnoreStart


### PR DESCRIPTION
…his can be null, despite being mandatory in iSite.

E.G: http://sandbox.bbc.co.uk/programmes/profiles/3HjNsmW9tbq9bqRTYYWLCFW/profiles-2014