### PR TITLE
PROGRAMMES-6840: Handle article/profile guids being passed to the wro…

### DIFF
--- a/src/Controller/Profiles/ShowController.php
+++ b/src/Controller/Profiles/ShowController.php
@@ -39,13 +39,8 @@ class ShowController extends BaseController
         }
 
         $guid = $isiteKeyHelper->convertKeyToGuid($key);
-
-        try {
-            /** @var IsiteResult $isiteResult */
-            $isiteResult = $isiteService->getByContentId($guid, $preview)->wait(true);
-        } catch (InvalidArgumentException $e) {
-            throw $this->createNotFoundException('No profiles found for guid.');
-        }
+        /** @var IsiteResult $isiteResult */
+        $isiteResult = $isiteService->getByContentId($guid, $preview)->wait(true);
 
         /** @var Profile $profile */
         $profiles = $isiteResult->getDomainModels();

--- a/src/ExternalApi/Isite/Mapper/ArticleMapper.php
+++ b/src/ExternalApi/Isite/Mapper/ArticleMapper.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace App\ExternalApi\Isite\Mapper;
 
 use App\ExternalApi\Isite\Domain\Article;
+use App\ExternalApi\Isite\WrongEntityTypeException;
 use InvalidArgumentException;
 use SimpleXMLElement;
 
@@ -17,7 +18,7 @@ class ArticleMapper extends Mapper
         $resultMetaData = $this->getMetaData($isiteObject);
         $guid = $this->getString($resultMetaData->guid);
         if (!$this->isArticle($resultMetaData)) {
-            throw new InvalidArgumentException(
+            throw new WrongEntityTypeException(
                 sprintf(
                     "iSite form with guid %s attempted to be mapped as article, but is not a article, is a %s",
                     $guid,

--- a/src/ExternalApi/Isite/Mapper/ProfileMapper.php
+++ b/src/ExternalApi/Isite/Mapper/ProfileMapper.php
@@ -5,6 +5,7 @@ namespace App\ExternalApi\Isite\Mapper;
 
 use App\Controller\Helpers\IsiteKeyHelper;
 use App\ExternalApi\Isite\Domain\Profile;
+use App\ExternalApi\Isite\WrongEntityTypeException;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
@@ -20,7 +21,7 @@ class ProfileMapper extends Mapper
         $guid = $this->getString($resultMetaData->guid);
         $key = $this->isiteKeyHelper->convertGuidToKey($guid);
         if (!$this->isProfile($resultMetaData)) {
-            throw new InvalidArgumentException(
+            throw new WrongEntityTypeException(
                 sprintf(
                     "iSite form with guid %s attempted to be mapped as profile, but is not a profile, is a %s",
                     $guid,


### PR DESCRIPTION
…ng controllers

I just saw a previous PR that fixed this by generically catching InvalidArgumentException, which is a shit idea, there needs to be a specific exception for this. Turns out there already was and it just wasn't being thrown, so this PR throws it.

Prevents links to /programmes/profiles/articleGUID and /programmes/articles/profileGUID from 500-ing. Which is not important. But the previous implementation made me nervous so I thought I'd fully fix it. 

See https://jira.dev.bbc.co.uk/browse/PROGRAMMES-6840