### PR TITLE
Fix article image size

### DIFF
--- a/src/Ds2013/Presenters/Domain/ContentBlock/Image/image.html.twig
+++ b/src/Ds2013/Presenters/Domain/ContentBlock/Image/image.html.twig
@@ -15,7 +15,7 @@
         'image',
         content_block.getBlock().getImageUrl(),
         256,
-        { 0: 1, 770: 1/2, 1008: '490px' },
+        { 0: 1, 770: 1/2, 1008: '945px' },
         { 'is_lazy_loaded': false, 'ratio': 'auto' }
     ) -}}
     {% if content_block.getBlock().getCaption() is not empty %}


### PR DESCRIPTION
Image slot is too small (490px) for a resultion were the image is mean to be around 945px.

I tested this fix it and is working fine but I'm not too familiar with the image sizing system in place so please let me know if any objections