### PR TITLE
Decrease the severity error of an invalid content block

### DIFF
--- a/src/ExternalApi/Isite/Mapper/ContentBlockMapper.php
+++ b/src/ExternalApi/Isite/Mapper/ContentBlockMapper.php
@@ -402,7 +402,7 @@ class ContentBlockMapper extends Mapper
             case 'contactform':
                 throw new HasContactFormException('Contact form found');
             default:
-                $this->logger->error('Invalid content block type. Found ' . $type);
+                $this->logger->warning('Invalid content block type. Found ' . $type);
                 break;
         }
 


### PR DESCRIPTION
Decrease the severity error of an invalid content block because is not critical, is set by editorial and it doesn't stop the page from being rendered.