### PR TITLE
DATCAP-90: updating instagram oembed endpoint

### DIFF
--- a/assets/js/third-party.js
+++ b/assets/js/third-party.js
@@ -174,7 +174,7 @@ define(['jquery-1.9', 'policy-service'], function($, policyService) {
         providers : [
             /* Flickr have currently broken their oEmbed API in Chrome and IE */
             /*new Provider("flickr", "photo", ["flickr\\.com/photos/.+","flic\\.kr/p/.+"], "http://flickr.com/services/oembed",{callbackparameter:'jsoncallback'}),*/
-            new Provider("instagram", "rich", ["instagr\\.?am(\\.com)?/.+"], "https://graph.facebook.com/v8.0/instagram_oembed?access_token=3693890007336150%7C25561916b38fe91a65c09d23dc81a858", {
+            new Provider("instagram", "rich", ["instagr\\.?am(\\.com)?/.+"], "https://graph.facebook.com/v8.0/instagram_oembed?access_token=2635578666704177%7C3328a16269cb548b497ec0c03c676494", {
                 format: 'json',
                 dataType: 'json'
             }),

--- a/assets/js/third-party.js
+++ b/assets/js/third-party.js
@@ -174,7 +174,7 @@ define(['jquery-1.9', 'policy-service'], function($, policyService) {
         providers : [
             /* Flickr have currently broken their oEmbed API in Chrome and IE */
             /*new Provider("flickr", "photo", ["flickr\\.com/photos/.+","flic\\.kr/p/.+"], "http://flickr.com/services/oembed",{callbackparameter:'jsoncallback'}),*/
-            new Provider("instagram", "rich", ["instagr\\.?am(\\.com)?/.+"], "https://api.instagram.com/oembed/", {
+            new Provider("instagram", "rich", ["instagr\\.?am(\\.com)?/.+"], "https://graph.facebook.com/v8.0/instagram_oembed?access_token=3693890007336150%7C25561916b38fe91a65c09d23dc81a858", {
                 format: 'json',
                 dataType: 'json'
             }),


### PR DESCRIPTION
Updating the oembed endpoint with new access token and app id

![Screen Shot 2020-11-02 at 12 20 34](https://user-images.githubusercontent.com/15611398/97867561-fce77000-1d05-11eb-8d7c-b139513be920.png)

https://jira.dev.bbc.co.uk/browse/DATCAP-90
