### PR TITLE
DATCAP-223: swapping out podcast urls to fix broken links

### DIFF
--- a/config/routes/3rd_party.yaml
+++ b/config/routes/3rd_party.yaml
@@ -79,11 +79,6 @@ podcast_download_low:
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction, route: '' }
     schemes: [https]
 
-podcast_other_podcasts:
-    path: /radio/categories/redirect
-    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction, route: '' }
-    schemes: [https]
-
 podcast_childrens_podcasts:
     path: /sounds/category/childrens
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction, route: '' }

--- a/config/routes/3rd_party.yaml
+++ b/config/routes/3rd_party.yaml
@@ -79,9 +79,18 @@ podcast_download_low:
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction, route: '' }
     schemes: [https]
 
-
 podcast_other_podcasts:
     path: /radio/categories/redirect
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction, route: '' }
+    schemes: [https]
+
+podcast_childrens_podcasts:
+    path: /sounds/category/childrens
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction, route: '' }
+    schemes: [https]
+
+podcast_sounds_podcasts:
+    path: /sounds/category/podcasts
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction, route: '' }
     schemes: [https]
 

--- a/templates/podcast/podcast.html.twig
+++ b/templates/podcast/podcast.html.twig
@@ -149,14 +149,18 @@
                         {% if genre is defined %}
                         <div>
                             <div class="icon-box br-box-page">
-                                <a class="icon-box__link br-box-page__link br-page-link-onbg015 br-page-linkhover-onbg015--hover" href="{{ path('podcast_other_podcasts', {'keys': genre.getUrlKey(), 'intent': 'podcast'}) }}">
+                                {% set href = genre.getUrlKey() == "childrens"
+                                  ? path('podcast_childrens_podcasts')
+                                  : path('podcast_sounds_podcasts')
+                                %}
+                                  <a class="icon-box__link br-box-page__link br-page-link-onbg015       br-page-linkhover-onbg015--hover" href="{{ href }}">
                                     <i class="icon-box__icon gelicon gelicon--podcast"></i>
                                     <div class="icon-box__hgroup">
                                         <h3 class="icon-box__title gamma">{{ tr('podcasts_suggestions') }}</h3>
                                     </div>
                                     <p class="icon-box__note micro"> {{ tr('see_all_podcasts') }}</p>
                                     {{ gelicon('basics', 'podcast', ' icon-box__icon gelicon gelicon--podcast') }}
-                                </a>
+                                  </a>
                             </div>
                         </div>
                         {% endif %}


### PR DESCRIPTION
Updating podcast links based on the following logic:

- if genre key is childrens => https://www.bbc.co.uk/sounds/category/childrens
- if genre key is anything other than childrens => https://www.bbc.co.uk/sounds/category/podcasts

Tests to check the various urls will be added as part of the `programmes-aws-live` automation testing

https://jira.dev.bbc.co.uk/browse/DATCAP-223