### PR TITLE
DATCAP-223: Adding learning podcast link

### DIFF
--- a/config/routes/3rd_party.yaml
+++ b/config/routes/3rd_party.yaml
@@ -84,6 +84,11 @@ podcast_childrens_podcasts:
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction, route: '' }
     schemes: [https]
 
+podcast_learning_podcasts:
+    path: /sounds/category/learning
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction, route: '' }
+    schemes: [https]
+
 podcast_sounds_podcasts:
     path: /sounds/category/podcasts
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction, route: '' }

--- a/src/Controller/Podcast/PodcastController.php
+++ b/src/Controller/Podcast/PodcastController.php
@@ -75,7 +75,7 @@ class PodcastController extends BaseController
 
         $promotions = $promotionsService->findAllActivePromotionsByEntityGroupedByType($coreEntity);
         $genre = null;
-        $otherPodcastsUrl = null;
+        $relatedPodcastsUrl = null;
 
         if ($programme) {
             $genres = $programme->getGenres();
@@ -83,16 +83,17 @@ class PodcastController extends BaseController
         }
         if ($genre) {
             $genre = $genre->getTopLevel();
+
             switch ($genre->getUrlKey()) {
-              case 'childrens':
-                  $otherPodcastsUrl = $router->generate('podcast_childrens_podcasts', [], UrlGeneratorInterface::ABSOLUTE_URL);
-                  break;
-              case 'learning':
-                  $otherPodcastsUrl = $router->generate('podcast_learning_podcasts', [], UrlGeneratorInterface::ABSOLUTE_URL);
-                  break;
-              default:
-                  $otherPodcastsUrl = $router->generate('podcast_sounds_podcasts', [], UrlGeneratorInterface::ABSOLUTE_URL);
-          }
+                case 'childrens':
+                    $relatedPodcastsUrl = $router->generate('podcast_childrens_podcasts', [], UrlGeneratorInterface::ABSOLUTE_URL);
+                    break;
+                case 'learning':
+                    $relatedPodcastsUrl = $router->generate('podcast_learning_podcasts', [], UrlGeneratorInterface::ABSOLUTE_URL);
+                    break;
+                default:
+                    $relatedPodcastsUrl = $router->generate('podcast_sounds_podcasts', [], UrlGeneratorInterface::ABSOLUTE_URL);
+            }
         }
 
         $schema = $this->getSchema($structuredDataHelper, $programme, $downloadableVersions, $coreEntity);
@@ -125,7 +126,7 @@ class PodcastController extends BaseController
             'promotions' => $promotions,
             'genre' => $genre,
             'soundsSubscribeUrl' => $soundsSubscribeUrl,
-            'podcastsUrl' => $otherPodcastsUrl
+            'relatedPodcastsUrl' => $relatedPodcastsUrl,
         ]);
     }
 

--- a/src/Controller/Podcast/PodcastController.php
+++ b/src/Controller/Podcast/PodcastController.php
@@ -75,12 +75,24 @@ class PodcastController extends BaseController
 
         $promotions = $promotionsService->findAllActivePromotionsByEntityGroupedByType($coreEntity);
         $genre = null;
+        $otherPodcastsUrl = null;
+
         if ($programme) {
             $genres = $programme->getGenres();
             $genre = reset($genres);
         }
         if ($genre) {
             $genre = $genre->getTopLevel();
+            switch ($genre->getUrlKey()) {
+              case 'childrens':
+                  $otherPodcastsUrl = $router->generate('podcast_childrens_podcasts', [], UrlGeneratorInterface::ABSOLUTE_URL);
+                  break;
+              case 'learning':
+                  $otherPodcastsUrl = $router->generate('podcast_learning_podcasts', [], UrlGeneratorInterface::ABSOLUTE_URL);
+                  break;
+              default:
+                  $otherPodcastsUrl = $router->generate('podcast_sounds_podcasts', [], UrlGeneratorInterface::ABSOLUTE_URL);
+          }
         }
 
         $schema = $this->getSchema($structuredDataHelper, $programme, $downloadableVersions, $coreEntity);
@@ -113,6 +125,7 @@ class PodcastController extends BaseController
             'promotions' => $promotions,
             'genre' => $genre,
             'soundsSubscribeUrl' => $soundsSubscribeUrl,
+            'podcastsUrl' => $otherPodcastsUrl
         ]);
     }
 

--- a/templates/podcast/podcast.html.twig
+++ b/templates/podcast/podcast.html.twig
@@ -149,7 +149,7 @@
                         {% if genre is defined %}
                         <div>
                             <div class="icon-box br-box-page">
-                                <a class="icon-box__link br-box-page__link br-page-link-onbg015 br-page-linkhover-onbg015--hover" href="{{ podcastsUrl }}">
+                                <a class="icon-box__link br-box-page__link br-page-link-onbg015 br-page-linkhover-onbg015--hover" href="{{ relatedPodcastsUrl }}">
                                     <i class="icon-box__icon gelicon gelicon--podcast"></i>
                                     <div class="icon-box__hgroup">
                                         <h3 class="icon-box__title gamma">{{ tr('podcasts_suggestions') }}</h3>

--- a/templates/podcast/podcast.html.twig
+++ b/templates/podcast/podcast.html.twig
@@ -149,15 +149,7 @@
                         {% if genre is defined %}
                         <div>
                             <div class="icon-box br-box-page">
-                                {% set genreValue = genre.getUrlKey() %}
-                                {% if genreValue == 'childrens' %}
-                                    {% set href = path('podcast_childrens_podcasts') %}
-                                {% elseif genreValue == 'learning' %}
-                                    {% set href = path('podcast_learning_podcasts') %}
-                                {% else %}
-                                    {% set href = path('podcast_sounds_podcasts') %}
-                                {% endif %}
-                                <a class="icon-box__link br-box-page__link br-page-link-onbg015 br-page-linkhover-onbg015--hover" href="{{ href }}">
+                                <a class="icon-box__link br-box-page__link br-page-link-onbg015 br-page-linkhover-onbg015--hover" href="{{ podcastsUrl }}">
                                     <i class="icon-box__icon gelicon gelicon--podcast"></i>
                                     <div class="icon-box__hgroup">
                                         <h3 class="icon-box__title gamma">{{ tr('podcasts_suggestions') }}</h3>

--- a/templates/podcast/podcast.html.twig
+++ b/templates/podcast/podcast.html.twig
@@ -149,10 +149,14 @@
                         {% if genre is defined %}
                         <div>
                             <div class="icon-box br-box-page">
-                                {% set href = genre.getUrlKey() == "childrens"
-                                    ? path('podcast_childrens_podcasts')
-                                    : path('podcast_sounds_podcasts')
-                                %}
+                                {% set genreValue = genre.getUrlKey() %}
+                                {% if genreValue == 'childrens' %}
+                                    {% set href = path('podcast_childrens_podcasts') %}
+                                {% elseif genreValue == 'learning' %}
+                                    {% set href = path('podcast_learning_podcasts') %}
+                                {% else %}
+                                    {% set href = path('podcast_sounds_podcasts') %}
+                                {% endif %}
                                 <a class="icon-box__link br-box-page__link br-page-link-onbg015 br-page-linkhover-onbg015--hover" href="{{ href }}">
                                     <i class="icon-box__icon gelicon gelicon--podcast"></i>
                                     <div class="icon-box__hgroup">


### PR DESCRIPTION
Moving logic to podcast controller to determine `other podcasts you may like` link destination:

if childrens: /sounds/category/childrens

if learning: /sounds/category/learning

else: /sounds/category/podcasts

https://jira.dev.bbc.co.uk/browse/DATCAP-223