### PR TITLE
Spike: Noindexing for series pages

### DIFF
--- a/src/Controller/FindByPid/SeriesController.php
+++ b/src/Controller/FindByPid/SeriesController.php
@@ -38,6 +38,19 @@ class SeriesController extends BaseProgrammeContainerController
         Breadcrumbs $breadcrumbs
     ) {
         $this->setAtiContentLabels('series', 'series');
+        $noIndexBrands = [
+            'b006pfjx', // North West Tonight
+            'b007t9y1', // Match of the Day
+            'p00yzlr0', // Line of Duty
+            'p070npjv', // Fleabag
+            'b006v5y2', // Saturday Kitchen
+            'b006mgyl', // BBC News
+            'm000lxp1', // Powering Britain
+            'b08s3bgz',  // Impossible
+        ];
+        if (in_array($programme->getTleo()->getPid(), $noIndexBrands)) {
+            $this->metaNoIndex = true;
+        }
         return parent::__invoke(
             $presenterFactory,
             $request,

--- a/src/Controller/ProgrammeEpisodes/PlayerController.php
+++ b/src/Controller/ProgrammeEpisodes/PlayerController.php
@@ -63,6 +63,20 @@ class PlayerController extends BaseProgrammeEpisodesController
             ->forRoute('Available', 'programme_episodes_player', $opts)
             ->toArray();
 
+        $noIndexBrands = [
+            'b006pfjx', // North West Tonight
+            'b007t9y1', // Match of the Day
+            'p00yzlr0', // Line of Duty
+            'p070npjv', // Fleabag
+            'b006v5y2', // Saturday Kitchen
+            'b006mgyl', // BBC News
+            'm000lxp1', // Powering Britain
+            'b08s3bgz',  // Impossible
+        ];
+        if (in_array($programme->getTleo()->getPid(), $noIndexBrands)) {
+            $this->metaNoIndex = true;
+        }
+
         return $this->renderWithChrome('programme_episodes/player.html.twig', [
             'programme' => $programme,
             'availableEpisodes' => $availableEpisodes,

--- a/templates/base_ds_amen.html.twig
+++ b/templates/base_ds_amen.html.twig
@@ -55,6 +55,7 @@
         {% block inline_head %}{% endblock %}
 
         {{ bbc_dotcom_head(null) }}
+        {% if meta_context.metaNoIndex() %}<meta name="robots" content="noindex">{% endif %}
         {% if meta_context.canonicalUrl() %}<link rel="canonical" href="{{ meta_context.canonicalUrl() }}">{% endif %}
         <meta name="theme-color" content="{{ branding.getColours().highlight.bg|default('#2B2B2B') }}">
         <meta name="description" content="{{ meta_context.description() }}">


### PR DESCRIPTION
We have previously implemented no-indexing for targeted episode pages (#1297). This spike looks at the same thing for series pages.

## Findings

- We can follow roughly the same approach, however the base template used by Series pages didn't have the noindex meta tag option, so I have added that.
- There is more than one type of series page. This PR implements the change for both 'series' and 'series episodes'
  - https://www.bbc.co.uk/programmes/p040tlqx
  - https://www.bbc.co.uk/programmes/p040tlqx/episodes/player
- Potentially series could be routed to brand pages (if the series is also the TLEO). I'm assuming such cases would not be part of the experiment.
- Although the logic to add the noindexing is trivial, we would probably want to share the noindex list among controllers to avoid duplication of data.

## Images

<img width="787" alt="Screenshot 2021-03-10 at 16 05 31" src="https://user-images.githubusercontent.com/1121817/110659442-7e6e7380-81ba-11eb-99b6-9ba2914cabe0.png">
<img width="809" alt="Screenshot 2021-03-10 at 15 34 10" src="https://user-images.githubusercontent.com/1121817/110659303-5d0d8780-81ba-11eb-8a6f-e41d401d24cb.png">

## Jira

https://jira.dev.bbc.co.uk/browse/DATCAP-219